### PR TITLE
 fix CentroidMapDiscretizerTest following new coordinate caching scheme

### DIFF
--- a/src/test/java/uk/ac/ox/oxfish/geography/CentroidMapDiscretizerTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/geography/CentroidMapDiscretizerTest.java
@@ -54,6 +54,7 @@ public class CentroidMapDiscretizerTest {
                         0,1
                 )
         );
+        state.getMap().recomputeTilesMPA();
 
         assertEquals(new Coordinate(0.125,.875,0),state.getMap().getCoordinates(0, 0));
         assertEquals(new Coordinate(.875,0.125,0),state.getMap().getCoordinates(3, 3));


### PR DESCRIPTION
(also includes a bit of tweaking to the tests: using Guava's `elementsEqual` instead of Apache's `isEqualCollection`, which doesn't check element order)