### PR TITLE
avoid boxing in BiomassLocalBiology arrays

### DIFF
--- a/src/main/java/uk/ac/ox/oxfish/biology/BiomassLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/BiomassLocalBiology.java
@@ -38,12 +38,12 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
     /**
      * the current amount of biomass in this spot
      */
-    private Double[] currentBiomass;
+    private double[] currentBiomass;
 
     /**
      * the maximum amount of biomass
      */
-    private Double[] carryingCapacity;
+    private double[] carryingCapacity;
 
 
     /**
@@ -52,7 +52,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
      * @param carryingCapacity the maximum amount of fish
      */
     public BiomassLocalBiology(
-            Double[] currentBiomass, Double[] carryingCapacity) {
+            double[] currentBiomass, double[] carryingCapacity) {
         Preconditions.checkArgument(currentBiomass.length==carryingCapacity.length);
 
         this.currentBiomass = Arrays.copyOf(currentBiomass,currentBiomass.length);
@@ -76,9 +76,9 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
         assert initialMaxCapacity>= initialMinCapacity;
         assert  initialMaxCapacity >=0;
         assert  initialMinCapacity <=1;
-        this.carryingCapacity = new Double[species];
+        this.carryingCapacity = new double[species];
         Arrays.fill(this.carryingCapacity, carryingCapacity);
-        this.currentBiomass = new Double[species];
+        this.currentBiomass = new double[species];
 
         for(int i=0; i<currentBiomass.length; i++)
         {
@@ -102,7 +102,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         final int index = species.getIndex();
         if(index>=this.currentBiomass.length)
             return 0d; //don't have it
@@ -116,7 +116,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
      * @return the carrying capacity for this species at this location
      */
     @Override
-    public Double getCarryingCapacity(Species species)
+    public double getCarryingCapacity(Species species)
     {
         final int index = species.getIndex();
         if(index>=this.carryingCapacity.length)
@@ -131,7 +131,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
      * @return the carrying capacity for this species at this location
      */
     @Override
-    public Double getCarryingCapacity(int index)
+    public double getCarryingCapacity(int index)
     {
         if(index>=this.carryingCapacity.length)
             return 0d; //don't have it
@@ -285,7 +285,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
 
 
     @Override
-    public Double[] getCurrentBiomass() {
+    public double[] getCurrentBiomass() {
         return currentBiomass;
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/ConstantBiomassDecorator.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/ConstantBiomassDecorator.java
@@ -18,7 +18,7 @@ public class ConstantBiomassDecorator implements VariableBiomassBasedBiology {
 
 
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return delegate.getBiomass(species);
     }
 
@@ -44,12 +44,12 @@ public class ConstantBiomassDecorator implements VariableBiomassBasedBiology {
 
 
     @Override
-    public Double getCarryingCapacity(Species species) {
+    public double getCarryingCapacity(Species species) {
         return delegate.getCarryingCapacity(species);
     }
 
     @Override
-    public Double getCarryingCapacity(int index) {
+    public double getCarryingCapacity(int index) {
         return delegate.getCarryingCapacity(index);
     }
 
@@ -64,7 +64,7 @@ public class ConstantBiomassDecorator implements VariableBiomassBasedBiology {
     }
 
     @Override
-    public Double[] getCurrentBiomass() {
+    public double[] getCurrentBiomass() {
         return delegate.getCurrentBiomass();
     }
 }

--- a/src/main/java/uk/ac/ox/oxfish/biology/ConstantHeterogeneousLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/ConstantHeterogeneousLocalBiology.java
@@ -43,7 +43,7 @@ public class ConstantHeterogeneousLocalBiology extends AbstractBiomassBasedBiolo
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return biomasses[species.getIndex()];
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/ConstantLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/ConstantLocalBiology.java
@@ -41,7 +41,7 @@ public class ConstantLocalBiology extends AbstractBiomassBasedBiology {
      * returned the fixed biomass
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return fixedBiomass;
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/EmptyLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/EmptyLocalBiology.java
@@ -39,7 +39,7 @@ public class EmptyLocalBiology implements LocalBiology
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return 0d;
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/GetterLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/GetterLocalBiology.java
@@ -82,7 +82,7 @@ public class GetterLocalBiology extends AbstractBiomassBasedBiology {
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
 
         if(species==this.species)
             return Math.max(0,biomass.apply(state));

--- a/src/main/java/uk/ac/ox/oxfish/biology/LocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/LocalBiology.java
@@ -42,7 +42,7 @@ public interface LocalBiology extends Startable
      * @param species  the species you care about
      * @return the biomass of this species
      */
-    Double getBiomass(Species species);
+    double getBiomass(Species species);
 
     /**
      * Tells the local biology that a fisher (or something anyway) fished this much biomass from this location

--- a/src/main/java/uk/ac/ox/oxfish/biology/SchoolLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/SchoolLocalBiology.java
@@ -56,7 +56,7 @@ public class SchoolLocalBiology extends AbstractBiomassBasedBiology {
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
 
         double sum = 0;
         for(InfiniteSchool school : schools)

--- a/src/main/java/uk/ac/ox/oxfish/biology/SingleSpecieLogisticDelayGrowthBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/SingleSpecieLogisticDelayGrowthBiology.java
@@ -20,7 +20,7 @@
 
 package uk.ac.ox.oxfish.biology;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.EvictingQueue;
 import sim.engine.SimState;
 import sim.engine.Steppable;
@@ -81,10 +81,10 @@ public class SingleSpecieLogisticDelayGrowthBiology extends AbstractBiomassBased
     public SingleSpecieLogisticDelayGrowthBiology(
             Species species, double currentBiomass, double maxBiomass, int yearDelays, double aParameter,
             double bParameter) {
-        Preconditions.checkArgument(yearDelays > 0, "Use undelayed biology rather than feeding 0 to a delayed one");
-        Preconditions.checkArgument(maxBiomass > 0);
-        Preconditions.checkArgument(currentBiomass <= maxBiomass);
-        Preconditions.checkArgument(currentBiomass >= 0);
+        checkArgument(yearDelays > 0, "Use undelayed biology rather than feeding 0 to a delayed one");
+        checkArgument(maxBiomass > 0);
+        checkArgument(currentBiomass <= maxBiomass);
+        checkArgument(currentBiomass >= 0);
         this.species = species;
         this.yearDelays = yearDelays;
         pastBiomass = EvictingQueue.create(yearDelays);
@@ -103,12 +103,10 @@ public class SingleSpecieLogisticDelayGrowthBiology extends AbstractBiomassBased
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species)
+    public double getBiomass(Species species)
     {
-        if(species == this.species)
-            return currentBiomass;
-        else
-            return null;
+        checkArgument(species == this.species, "%s != %s", species, this.species);
+        return currentBiomass;
     }
 
     /**
@@ -123,7 +121,7 @@ public class SingleSpecieLogisticDelayGrowthBiology extends AbstractBiomassBased
         //focus on only the one you care about!
         double biomassFished = caught.getWeightCaught(this.species);
 
-        Preconditions.checkArgument(biomassFished <= currentBiomass);
+        checkArgument(biomassFished <= currentBiomass);
         currentBiomass-= biomassFished;
 
     }

--- a/src/main/java/uk/ac/ox/oxfish/biology/UnfishableLocalBiologyDecorator.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/UnfishableLocalBiologyDecorator.java
@@ -52,7 +52,7 @@ public class UnfishableLocalBiologyDecorator implements LocalBiology {
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return decorated.getBiomass(species);
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/VariableBiomassBasedBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/VariableBiomassBasedBiology.java
@@ -21,13 +21,13 @@
 package uk.ac.ox.oxfish.biology;
 
 public interface VariableBiomassBasedBiology extends LocalBiology {
-    Double getCarryingCapacity(Species species);
+    double getCarryingCapacity(Species species);
 
-    Double getCarryingCapacity(int index);
+    double getCarryingCapacity(int index);
 
     void setCarryingCapacity(Species s, double newCarryingCapacity);
 
     void setCurrentBiomass(Species s, double newCurrentBiomass);
 
-    Double[] getCurrentBiomass();
+    double[] getCurrentBiomass();
 }

--- a/src/main/java/uk/ac/ox/oxfish/biology/complicated/AbundanceLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/complicated/AbundanceLocalBiology.java
@@ -83,7 +83,7 @@ public class AbundanceLocalBiology implements LocalBiology
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
 
         if(Double.isNaN(lastComputedBiomass[species.getIndex()] )) {
             lastComputedBiomass[species.getIndex()] = FishStateUtilities.weigh(

--- a/src/main/java/uk/ac/ox/oxfish/biology/growers/IndependentLogisticBiomassGrower.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/growers/IndependentLogisticBiomassGrower.java
@@ -81,7 +81,7 @@ public class IndependentLogisticBiomassGrower implements Startable, Steppable{
         {
             //grow fish
 
-            Double[] currentBiomasses = biology.getCurrentBiomass();
+            double[] currentBiomasses = biology.getCurrentBiomass();
 
 
 
@@ -89,7 +89,7 @@ public class IndependentLogisticBiomassGrower implements Startable, Steppable{
             assert currentBiomasses[speciesIndex] >=0;
             //grows logistically
 
-            Double carryingCapacity = biology.getCarryingCapacity(speciesIndex);
+            double carryingCapacity = biology.getCarryingCapacity(speciesIndex);
             if(carryingCapacity > FishStateUtilities.EPSILON && carryingCapacity > currentBiomasses[speciesIndex]) {
                 double oldBiomass = currentBiomasses[speciesIndex];
                 currentBiomasses[speciesIndex] = logisticStep(currentBiomasses[speciesIndex],

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/GenericBiomassInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/GenericBiomassInitializer.java
@@ -134,16 +134,16 @@ public class GenericBiomassInitializer extends AbstractBiologyInitializer
         }
 
         //create carrying capcities and put them in
-        Double[] carringCapacities = new  Double[biology.getSize()];
-        Double[] currentCapacity = new Double[biology.getSize()];
+        double[] carringCapacities = new  double[biology.getSize()];
+        double[] currentCapacity = new double[biology.getSize()];
         for(Species species : biology.getSpecies())
         {
-            Double k = carryingCapacity.get(species.getIndex()).apply(random) *
+            double k = carryingCapacity.get(species.getIndex()).apply(random) *
                     manager.getWeight(species, seaTile,map ,random );
             carringCapacities[species.getIndex()] = k;
 
-            Double min = minInitialCapacity.apply(random);
-            Double max = maxInitialCapacity.apply(random);
+            double min = minInitialCapacity.apply(random);
+            double max = maxInitialCapacity.apply(random);
             currentCapacity[species.getIndex()] =
                     ((max - min)*random.nextDouble(true, true) + min)
                             * k;

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/SingleSpeciesBiomassInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/SingleSpeciesBiomassInitializer.java
@@ -199,8 +199,8 @@ public class SingleSpeciesBiomassInitializer implements BiologyInitializer{
             return new EmptyLocalBiology();
         else{
             numberOfHabitableCells++;
-            Double[] currentBiomass = new Double[biology.getSize()];
-            Double[] carryingCapacity = new Double[biology.getSize()];
+            double[] currentBiomass = new double[biology.getSize()];
+            double[] carryingCapacity = new double[biology.getSize()];
             Arrays.fill(currentBiomass,0d);
             Arrays.fill(carryingCapacity,0d);
             return new BiomassLocalBiology(currentBiomass,

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesBoxInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesBoxInitializer.java
@@ -163,8 +163,8 @@ public class TwoSpeciesBoxInitializer extends  AbstractBiologyInitializer {
 
 
         BiomassLocalBiology toReturn =  new BiomassLocalBiology(
-                new Double[]{random.nextDouble() * firstSpeciesCapacity,random.nextDouble() * secondSpeciesCapacity},
-                new Double[]{firstSpeciesCapacity,secondSpeciesCapacity});
+                new double[]{random.nextDouble() * firstSpeciesCapacity,random.nextDouble() * secondSpeciesCapacity},
+                new double[]{firstSpeciesCapacity,secondSpeciesCapacity});
         biologies.put(seaTile,toReturn);
         return toReturn;
     }

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesRockyLogisticInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesRockyLogisticInitializer.java
@@ -82,11 +82,11 @@ public class TwoSpeciesRockyLogisticInitializer extends RockyLogisticInitializer
 
 
             BiomassLocalBiology local = new BiomassLocalBiology(
-                    new Double[]{
+                    new double[]{
                             carryingCapacityFirst * random.nextDouble(),
                             carryingCapacitySecond * random.nextDouble()
                     },
-                    new Double[]{
+                    new double[]{
                             carryingCapacityFirst, carryingCapacitySecond
                     }
             );

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/YellowBycatchInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/YellowBycatchInitializer.java
@@ -128,7 +128,7 @@ public class YellowBycatchInitializer implements BiologyInitializer {
     /**
      * the original biomass assigned for each local biology. Makes resetting quick
      */
-    private HashMap<VariableBiomassBasedBiology,Double[]> originalBiomass = new HashMap<>();
+    private HashMap<VariableBiomassBasedBiology, double[]> originalBiomass = new HashMap<>();
 
 
     private final double targetDiffusionRate;
@@ -638,7 +638,7 @@ public class YellowBycatchInitializer implements BiologyInitializer {
     public void resetLocalBiology(Species species){
 
         //reset!
-        for (Map.Entry<VariableBiomassBasedBiology, Double[]> local : originalBiomass.entrySet()) {
+        for (Map.Entry<VariableBiomassBasedBiology, double[]> local : originalBiomass.entrySet()) {
             local.getKey().setCurrentBiomass(species,local.getValue()[species.getIndex()]);
 
         }

--- a/src/main/java/uk/ac/ox/oxfish/geography/SeaTile.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/SeaTile.java
@@ -142,7 +142,7 @@ public class SeaTile implements Startable, LocalBiology{
      * @param species  the species you care about
      * @return the biomass of this species
      */
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return biology.getBiomass(species);
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/geography/osmose/LocalOsmoseByBiomassBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/osmose/LocalOsmoseByBiomassBiology.java
@@ -65,7 +65,7 @@ public class LocalOsmoseByBiomassBiology extends AbstractBiomassBasedBiology
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
         return delegate.getBiomass(species);
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/geography/osmose/LocalOsmoseWithoutRecruitmentBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/osmose/LocalOsmoseWithoutRecruitmentBiology.java
@@ -87,7 +87,7 @@ public class LocalOsmoseWithoutRecruitmentBiology extends AbstractBiomassBasedBi
      * @return the biomass of this species
      */
     @Override
-    public Double getBiomass(Species species) {
+    public double getBiomass(Species species) {
 
         return getBiomass(species.getIndex());
 

--- a/src/test/java/uk/ac/ox/oxfish/biology/LogisticGrowthTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/biology/LogisticGrowthTest.java
@@ -35,7 +35,7 @@ public class LogisticGrowthTest
     public void logisticGrowthWorks() throws Exception {
 
         BiomassLocalBiology bio = new BiomassLocalBiology(
-                new Double[]{100d,200d,0d}, new Double[]{100d,400d,0d}
+                new double[]{100d,200d,0d}, new double[]{100d,400d,0d}
         );
         Species species0 = new Species("0"); species0.resetIndexTo(0);
         Species species1 = new Species("1"); species1.resetIndexTo(1);
@@ -82,7 +82,7 @@ public class LogisticGrowthTest
     public void logisticGrowthWorksOneSpecies() throws Exception {
 
         BiomassLocalBiology bio = new BiomassLocalBiology(
-                new Double[]{80d,200d,0d}, new Double[]{100d,400d,0d}
+                new double[]{80d,200d,0d}, new double[]{100d,400d,0d}
         );
         Species species0 = new Species("0"); species0.resetIndexTo(0);
         Species species1 = new Species("1"); species1.resetIndexTo(1);

--- a/src/test/java/uk/ac/ox/oxfish/biology/growers/CommonLogisticGrowerTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/biology/growers/CommonLogisticGrowerTest.java
@@ -61,8 +61,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void allocateEqually() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(
@@ -80,8 +80,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void fillToBrim() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(
@@ -100,8 +100,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void alreadyFull() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{200d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{200d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{200d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{200d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(
@@ -119,8 +119,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void allocateMoreToEmptyOne() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{0d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{0d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(
@@ -138,8 +138,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void allocateMoreToEmptyOneAgain() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{0d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{0d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(
@@ -157,8 +157,8 @@ public class CommonLogisticGrowerTest {
     @Test
     public void allocateMoreToEmptyOneWithWeight() {
 
-        BiomassLocalBiology first = new BiomassLocalBiology(new Double[]{0d},new Double[]{200d});
-        BiomassLocalBiology second = new BiomassLocalBiology(new Double[]{100d},new Double[]{200d});
+        BiomassLocalBiology first = new BiomassLocalBiology(new double[]{0d}, new double[]{200d});
+        BiomassLocalBiology second = new BiomassLocalBiology(new double[]{100d}, new double[]{200d});
         ArrayList<BiomassLocalBiology> biologies = Lists.newArrayList(first, second);
 
         CommonLogisticGrower.allocateBiomassProportionally(

--- a/src/test/java/uk/ac/ox/oxfish/biology/growers/DerisoSchnuteIndependentGrowerTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/biology/growers/DerisoSchnuteIndependentGrowerTest.java
@@ -43,8 +43,8 @@ public class DerisoSchnuteIndependentGrowerTest {
         //numbers are from sablefish
 
         BiomassLocalBiology biology =
-                new BiomassLocalBiology(new Double[]{527154d},
-                                        new Double[]{527154d});
+                new BiomassLocalBiology(new double[]{527154d},
+                                        new double[]{527154d});
 
         ArrayList<Double> biomasses = Lists.newArrayList(527154d, 527154d, 527154d, 527154d, 527154d, 527154d);
         DerisoSchnuteIndependentGrower grower =
@@ -76,8 +76,8 @@ public class DerisoSchnuteIndependentGrowerTest {
         //numbers are from sablefish
 
         BiomassLocalBiology biology =
-                new BiomassLocalBiology(new Double[]{527154d},
-                                        new Double[]{527154d});
+                new BiomassLocalBiology(new double[]{527154d},
+                                        new double[]{527154d});
 
         ArrayList<Double> biomasses = Lists.newArrayList(527154d, 527154d, 527154d, 527154d, 527154d, 527154d);
         DerisoSchnuteIndependentGrower grower =
@@ -112,8 +112,8 @@ public class DerisoSchnuteIndependentGrowerTest {
         double virginB = 8883d;
         double virginV = 85.13962;
         BiomassLocalBiology biology =
-                new BiomassLocalBiology(new Double[]{virginB},
-                                        new Double[]{virginB});
+                new BiomassLocalBiology(new double[]{virginB},
+                                        new double[]{virginB});
 
         ArrayList<Double> biomasses = Lists.newArrayList(virginB, virginB, virginB, virginB, virginB,
                                                          virginB, virginB, virginB, virginB, virginB,


### PR DESCRIPTION
In the `BiomassLocalBiology`, the `currentBiomass` and `carryingCapacity` are currently arrays of boxed doubles (`Double[]`) instead of raw arrays (`double[]`).

I took a shot at turning them into raw arrays, since boxing is costly in terms of performance and I couldn't identify any reason why it was necessary in this case (@CarrKnight , unless I missed something?)

The conversion was pretty straightforward. The only slightly more delicate change is in `SingleSpecieLogisticDelayGrowthBiology.getBiomass(Species species)`, which used to return `null` if the `species` argument was not the species from the instance. I'm now calling `checkArgument` instead, which will raise an exception in case of a mismatch. I think this should be OK, as the return value is never actually checked against `null` anyway (the compiler would have told us if it was).