### PR TITLE
revise argument check in BiomassLocalBiology.setCurrentBiomass

### DIFF
--- a/src/main/java/uk/ac/ox/oxfish/biology/BiomassLocalBiology.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/BiomassLocalBiology.java
@@ -214,7 +214,7 @@ public class BiomassLocalBiology extends AbstractBiomassBasedBiology implements 
         final int index = s.getIndex();
         if(index >=currentBiomass.length)
             growArrays(index +1);
-        Preconditions.checkArgument(currentBiomass[index] <= carryingCapacity[index],
+        Preconditions.checkArgument(newCurrentBiomass <= carryingCapacity[index],
                                     "the new current biomass is higher than carrying capacity!");
 
         currentBiomass[index] = newCurrentBiomass;


### PR DESCRIPTION
Based on the method's javadoc and on the checkArgument error message, I'm assuming that it's the new current biomass that should be checked instead of the previous one.