### PR TITLE
add SeaTile::isLand and SeaTile::isWater methods...

### DIFF
--- a/src/main/java/uk/ac/ox/oxfish/biology/BiomassDiffuserContainer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/BiomassDiffuserContainer.java
@@ -119,7 +119,7 @@ public class BiomassDiffuserContainer implements Steppable {
         final List<SeaTile> tiles = map.getAllSeaTilesExcludingLandAsList().stream().filter(new Predicate<SeaTile>() {
             @Override
             public boolean test(SeaTile tile) {
-                return tile.getAltitude() < 0 && tile.getBiology() instanceof BiomassLocalBiology;
+                return tile.isWater() && tile.getBiology() instanceof BiomassLocalBiology;
             }
         }).collect(
                 Collectors.toList());
@@ -202,7 +202,7 @@ public class BiomassDiffuserContainer implements Steppable {
         for(Object inBag : mooreNeighbors)
         {
             SeaTile newTile = (SeaTile) inBag;
-            if (newTile.getAltitude() < 0 && newTile.getBiology() instanceof BiomassLocalBiology)
+            if (newTile.isWater() && newTile.getBiology() instanceof BiomassLocalBiology)
             {
                 toKeep.add(newTile);
             }

--- a/src/main/java/uk/ac/ox/oxfish/biology/complicated/AbstractAbundanceDiffuser.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/complicated/AbstractAbundanceDiffuser.java
@@ -165,7 +165,7 @@ public abstract class AbstractAbundanceDiffuser implements AbundanceDiffuser {
             SeaTile newTile = (SeaTile) inBag;
             if (biologies.containsKey(newTile))
             {
-                assert newTile.getAltitude() <= 0;
+                assert newTile.isWater();
                 assert newTile.getBiology() instanceof AbundanceLocalBiology;
                 toKeep.add(newTile);
             }

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightInitializer.java
@@ -72,7 +72,7 @@ public class FromLeftToRightInitializer extends AbstractBiologyInitializer{
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map)
     {
-        if (seaTile.getAltitude() > 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         else
             return new ConstantLocalBiology(maximumBiomass*

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightMixedInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightMixedInitializer.java
@@ -72,7 +72,7 @@ public class FromLeftToRightMixedInitializer extends AbstractBiologyInitializer 
     public LocalBiology generateLocal(
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
-        if (seaTile.getAltitude() > 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         else {
             double correctBiomass = maximumBiomass*

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightSplitInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/FromLeftToRightSplitInitializer.java
@@ -66,7 +66,7 @@ public class FromLeftToRightSplitInitializer extends AbstractBiologyInitializer 
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map)
     {
-        if (seaTile.getAltitude() > 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         else
         if(seaTile.getGridY() < mapHeightInCells/2d)
@@ -100,7 +100,7 @@ public class FromLeftToRightSplitInitializer extends AbstractBiologyInitializer 
             int height = map.getHeight();
             int y = random.nextInt(height);
             SeaTile toChange = (SeaTile) baseGrid.get(x, y);
-            if (toChange.getAltitude() > 0) //land is cool man
+            if (toChange.isLand()) //land is cool man
             {
                 assert toChange.getBiomass(null) <= 0;
                 continue;

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/IndependentLogisticInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/IndependentLogisticInitializer.java
@@ -82,7 +82,7 @@ public class IndependentLogisticInitializer extends AbstractBiologyInitializer {
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
 
-        if (seaTile.getAltitude() >= 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         else
         {

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/LinearGetterBiologyInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/LinearGetterBiologyInitializer.java
@@ -90,7 +90,7 @@ public class LinearGetterBiologyInitializer implements BiologyInitializer {
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
 
-        if(seaTile.getAltitude()>=0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
 
         Species species = biology.getSpecie(0);

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/MultipleSpeciesAbundanceInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/MultipleSpeciesAbundanceInitializer.java
@@ -126,7 +126,7 @@ public class MultipleSpeciesAbundanceInitializer implements AllocatedBiologyInit
      */
     public static LocalBiology generateAbundanceBiologyExceptOnLand(
             GlobalBiology biology, SeaTile seaTile, HashMap<SeaTile, AbundanceLocalBiology> locals) {
-        if(seaTile.getAltitude() >= 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
 
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/MultipleSpeciesDerisoInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/MultipleSpeciesDerisoInitializer.java
@@ -183,7 +183,7 @@ public class MultipleSpeciesDerisoInitializer implements AllocatedBiologyInitial
             int mapWidthInCells, NauticalMap map) {
 
 
-        if(seaTile.getAltitude() >= 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         else
         {

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/OneSpeciesInfiniteSchoolsInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/OneSpeciesInfiniteSchoolsInitializer.java
@@ -113,7 +113,7 @@ public class OneSpeciesInfiniteSchoolsInitializer extends AbstractBiologyInitial
     public LocalBiology generateLocal(
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
-        if(seaTile.getAltitude()>=0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
         return new SchoolLocalBiology(schools,seaTile);
     }

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/OsmoseBiologyInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/OsmoseBiologyInitializer.java
@@ -117,7 +117,7 @@ public class OsmoseBiologyInitializer implements BiologyInitializer {
             int mapWidthInCells, NauticalMap map) {
         OsmoseSimulation simulation = ((OsmoseGlobalBiology) biology).getSimulation();
 
-        if(seaTile.getAltitude()>0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
 
 

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/RandomConstantBiologyInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/RandomConstantBiologyInitializer.java
@@ -71,7 +71,7 @@ public class RandomConstantBiologyInitializer extends AbstractBiologyInitializer
     {
         assert minBiomass > maxBiomass;
 
-            if (seaTile.getAltitude() > 0)
+            if (seaTile.isLand())
                 return new EmptyLocalBiology();
             else
                 return new ConstantLocalBiology(random.nextDouble()* (maxBiomass - minBiomass)+ minBiomass);

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/RockyLogisticInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/RockyLogisticInitializer.java
@@ -97,7 +97,7 @@ public class RockyLogisticInitializer extends AbstractBiologyInitializer
     public LocalBiology generateLocal(
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
-        if(seaTile.getAltitude() >=0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
         else
         {

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/SingleSpeciesAbundanceInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/SingleSpeciesAbundanceInitializer.java
@@ -199,7 +199,7 @@ public class SingleSpeciesAbundanceInitializer implements BiologyInitializer
             int mapWidthInCells, NauticalMap map) {
 
 
-        if(seaTile.getAltitude() >= 0)
+        if (seaTile.isLand())
             return new EmptyLocalBiology();
         //weight we want to allocate to this area
         double weight = intialAbundanceAllocator.allocate(seaTile,

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesBoxInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesBoxInitializer.java
@@ -129,7 +129,7 @@ public class TwoSpeciesBoxInitializer extends  AbstractBiologyInitializer {
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
 
-        if(seaTile.getAltitude() > 0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
 
         //start by assuming both species are in

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesRockyLogisticInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/TwoSpeciesRockyLogisticInitializer.java
@@ -67,7 +67,7 @@ public class TwoSpeciesRockyLogisticInitializer extends RockyLogisticInitializer
     public LocalBiology generateLocal(
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
-        if(seaTile.getAltitude() >=0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
         else
         {

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/YellowBycatchInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/YellowBycatchInitializer.java
@@ -204,7 +204,7 @@ public class YellowBycatchInitializer implements BiologyInitializer {
     public LocalBiology generateLocal(
             GlobalBiology biology, SeaTile seaTile, MersenneTwisterFast random, int mapHeightInCells,
             int mapWidthInCells, NauticalMap map) {
-        if(seaTile.getAltitude()>=0)
+        if(seaTile.isLand())
             return new EmptyLocalBiology();
 
         //prepare an empty biology

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/allocator/AllocatorManager.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/allocator/AllocatorManager.java
@@ -121,7 +121,7 @@ public class AllocatorManager {
                     //what's the weight here?
                     double weightHere =
                             //weight is always 0 above ground (or zeroed out)
-                            tile.getAltitude() >= 0 || zeroedArea.contains(tile)?
+                            tile.isLand() || zeroedArea.contains(tile)?
                                     0 :
                                     //otherwise allocate according to the right allocator
                                     allocators.get(speciesMap.getKey()).allocate(
@@ -160,7 +160,7 @@ public class AllocatorManager {
         {
             return
                     //if it's above land, return 0
-                    tile.getAltitude() >= 0 ?
+                    tile.isLand() ?
                             0 :
                             //otherwise allocate according to the right allocator
                             allocators.get(species).allocate(

--- a/src/main/java/uk/ac/ox/oxfish/biology/initializer/allocator/PyramidsAllocator.java
+++ b/src/main/java/uk/ac/ox/oxfish/biology/initializer/allocator/PyramidsAllocator.java
@@ -76,7 +76,7 @@ public class PyramidsAllocator implements BiomassAllocator {
                     x = random.nextInt(mapWidth);
                     y = random.nextInt(mapHeight);
                 }
-                while (map.getSeaTile(x, y).getAltitude() > 0);
+                while (map.getSeaTile(x, y).isLand());
                 biomass.set(x, y, peakBiomass);
                 for (int spread = 1; spread < maxSpread; spread++) {
 
@@ -84,14 +84,14 @@ public class PyramidsAllocator implements BiomassAllocator {
                     //vertical border
                     for (int h = -spread; h <= spread; h++) {
                         SeaTile border = map.getSeaTile(x - spread, y + h);
-                        if (border != null && border.getAltitude() < 0) {
+                        if (border != null && border.isWater()) {
 
                             biomass.set(x - spread, y + h,
                                         Math.min(biomass.get(x-spread,y+h) + Math.pow(smoothingValue, spread) * peakBiomass,peakBiomass));
 
                         }
                         border = map.getSeaTile(x + spread, y + h);
-                        if (border != null && border.getAltitude() < 0) {
+                        if (border != null && border.isWater()) {
                             biomass.set(x + spread, y + h,
                                         Math.min(biomass.get(x+spread,y+h) + Math.pow(smoothingValue, spread) * peakBiomass,peakBiomass));
                         }
@@ -101,13 +101,13 @@ public class PyramidsAllocator implements BiomassAllocator {
 
                     for (int w = -spread + 1; w < spread; w++) {
                         SeaTile border = map.getSeaTile(x + w, y - spread);
-                        if (border != null && border.getAltitude() < 0) {
+                        if (border != null && border.isWater()) {
                             biomass.set(x + w, y - spread,
                                         Math.min(biomass.get(x+w,y-spread) + Math.pow(smoothingValue, spread) * peakBiomass,peakBiomass));
 
                         }
                         border = map.getSeaTile(x + w, y + spread);
-                        if (border != null && border.getAltitude() < 0) {
+                        if (border != null && border.isWater()) {
                             biomass.set(x + w, y + spread,
                                         Math.min(biomass.get(x+w,y+spread) + Math.pow(smoothingValue, spread) * peakBiomass,peakBiomass));
                         }

--- a/src/main/java/uk/ac/ox/oxfish/experiments/FirstPaper.java
+++ b/src/main/java/uk/ac/ox/oxfish/experiments/FirstPaper.java
@@ -172,7 +172,7 @@ public class FirstPaper
         for (int x = 0; x < state.getMap().getWidth(); x++)
             for (int y = 0; y < state.getMap().getHeight(); y++) {
                 SeaTile seaTile = state.getMap().getSeaTile(x, y);
-                if(seaTile.getAltitude()<0)
+                if(seaTile.isWater())
                     blue[x][state.getMap().getHeight() - y - 1] = ((VariableBiomassBasedBiology) seaTile.
                             getBiology()).getCarryingCapacity(state.getSpecies().get(1));
             }

--- a/src/main/java/uk/ac/ox/oxfish/fisher/Fisher.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/Fisher.java
@@ -758,7 +758,7 @@ public class Fisher implements Steppable, Startable{
     {
         //preamble
         SeaTile here = status.getLocation();
-        Preconditions.checkState(here.getAltitude() < 0, "can't fish on land!");
+        Preconditions.checkState(here.isWater(), "can't fish on land!");
         //compute the catches (but kill nothing yet)
         Pair<Catch, Catch> catchesAndKept = computeCatchesHere(status.getLocation(),
                                                                localBiology,

--- a/src/main/java/uk/ac/ox/oxfish/fisher/actions/Fishing.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/actions/Fishing.java
@@ -62,7 +62,7 @@ public class Fishing implements Action
     @Override
     public ActionResult act(FishState model, Fisher agent, Regulation regulation, double hoursLeft) {
         Preconditions.checkArgument(agent.isAtDestination()); //you arrived
-        Preconditions.checkArgument(agent.getLocation().getAltitude() <= 0); //you are at sea
+        Preconditions.checkArgument(agent.getLocation().isWater()); //you are at sea
         Preconditions.checkState(
                 regulation.canFishHere(agent, agent.getLocation(), model) || accruedHours > 0 ||
         agent.isCheater()); //i should be allowed to fish here!

--- a/src/main/java/uk/ac/ox/oxfish/fisher/actions/fads/DeployFad.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/actions/fads/DeployFad.java
@@ -19,8 +19,7 @@ public class DeployFad implements FadAction {
 
     @Override
     public boolean isPossible(FishState model, Fisher fisher) {
-        return fisher.getLocation().getAltitude() <= 0 &&
-            getFadManager(fisher).getNumFadsInStock() > 0;
+        return fisher.getLocation().isWater() && getFadManager(fisher).getNumFadsInStock() > 0;
     }
 
     @Override

--- a/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/acquisition/HillClimberAcquisitionFunction.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/acquisition/HillClimberAcquisitionFunction.java
@@ -74,7 +74,7 @@ public class HillClimberAcquisitionFunction implements  AcquisitionFunction
             //remove a neighbor
             SeaTile option = (SeaTile) mooreNeighbors.remove(0);
             //if it is better, restart search at that neighbor!
-            if(option.getAltitude()<0 && !checkedAlready.contains(option) &&
+            if(option.isWater() && !checkedAlready.contains(option) &&
                     regression.predict(location, time, fisher,state )
                             < regression.predict(option, time, fisher,state )) {
                 location = option;

--- a/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/regression/numerical/AbstractKernelRegression.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/regression/numerical/AbstractKernelRegression.java
@@ -117,7 +117,7 @@ public abstract class AbstractKernelRegression implements GeographicalRegression
     @Override
     public double predict(SeaTile tile, double time, Fisher fisher, FishState model) {
 
-        if(tile.getAltitude()>=0)
+        if(tile.isLand())
             return Double.NaN;
         else
             return predict(tile.getGridX(),tile.getGridY(),time);

--- a/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/regression/numerical/NearestNeighborRegression.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/heatmap/regression/numerical/NearestNeighborRegression.java
@@ -152,7 +152,7 @@ public class NearestNeighborRegression implements GeographicalRegression<Double>
     @Override
     public double predict(SeaTile tile, double time, Fisher fisher, FishState model) {
 
-        if(tile.getAltitude()>=0)
+        if (tile.isLand())
             return Double.NaN;
         else
             return predict(ObservationExtractor.convertToFeatures(tile, time, fisher, extractors, model));

--- a/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/FavoriteDestinationStrategy.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/FavoriteDestinationStrategy.java
@@ -110,7 +110,7 @@ public class FavoriteDestinationStrategy implements DestinationStrategy {
     public void setFavoriteSpot(SeaTile favoriteSpot) {
         this.favoriteSpot = favoriteSpot;
 
-        Preconditions.checkArgument(this.favoriteSpot.getAltitude()<0);
+        Preconditions.checkArgument(this.favoriteSpot.isWater());
     }
 
 

--- a/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/HeatmapDestinationStrategy.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/HeatmapDestinationStrategy.java
@@ -172,10 +172,10 @@ public class HeatmapDestinationStrategy implements DestinationStrategy, TripList
 
         //find the optimal
         SeaTile optimal = acquisition.pick(model.getMap(), heatmap, model, fisher, delegate.getFavoriteSpot() );
-        Preconditions.checkState(optimal.getAltitude()<0);
+        Preconditions.checkState(optimal.isWater());
         if(model.getRandom().nextDouble()<=probability.getExplorationProbability()) {
             optimal = explorationStep.randomStep(model, model.getRandom(), fisher, optimal);
-            Preconditions.checkState(optimal.getAltitude()<0);
+            Preconditions.checkState(optimal.isWater());
         }
         delegate.setFavoriteSpot(optimal);
     }

--- a/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/LogitDestinationStrategy.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/LogitDestinationStrategy.java
@@ -222,7 +222,7 @@ public class LogitDestinationStrategy implements DestinationStrategy{
 
 
             destination = this.input.getLastExtraction().get(armChosen);
-            if(destination!=null && destination.getAltitude()>0)
+            if(destination!=null && destination.isLand())
                 destination=null;
             if(numberOfTrials++>100) {
                 Log.warn("Failed to compute any valid logit here, failed to adapt");

--- a/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/PerTripIterativeDestinationStrategy.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/PerTripIterativeDestinationStrategy.java
@@ -86,7 +86,7 @@ public class PerTripIterativeDestinationStrategy implements DestinationStrategy 
                 new Actuator<Fisher,SeaTile>() {
                     @Override
                     public void apply(Fisher fisher, SeaTile change, FishState model) {
-                        if (change.getAltitude() < 0) //ignores "go to land" commands
+                        if (change.isWater()) //ignores "go to land" commands
                             delegate.setFavoriteSpot(change);
                     }
                 },

--- a/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/factory/GravitationalSearchDestinationFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/strategies/destination/factory/GravitationalSearchDestinationFactory.java
@@ -133,12 +133,12 @@ public class GravitationalSearchDestinationFactory implements AlgorithmFactory<P
                 variable[1] = Math.max(Math.min(variable[1], state.getMap().getHeight() - 1), 0);
 
                 SeaTile presumedLocation = map.getSeaTile((int) variable[0], (int) variable[1]);
-                if(presumedLocation.getAltitude()>=0)
+                if(presumedLocation.isLand())
                 {
                     Object[] options = map.getMooreNeighbors(presumedLocation, 3).stream().filter(new Predicate() {
                         @Override
                         public boolean test(Object o) {
-                            return ((SeaTile) o).getAltitude() < 0;
+                            return ((SeaTile) o).isWater();
                         }
                     }).toArray();
                     SeaTile tile;

--- a/src/main/java/uk/ac/ox/oxfish/geography/NauticalMapFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/NauticalMapFactory.java
@@ -199,7 +199,7 @@ public class NauticalMapFactory {
                 for (int x = 0; x < width; x++)
                     for (int y = 0; y < height; y++) {
                         SeaTile tile = (SeaTile) baseGrid.field[x][y];
-                        if (tile.getAltitude() < 0)
+                        if (!tile.isLand())
                             continue; //if it's ocean, don't bother
 
                         Bag neighbors = new Bag();
@@ -207,7 +207,7 @@ public class NauticalMapFactory {
                         //count how many neighbors are ocean
                         int seaNeighbors = 0;
                         for (Object neighbor : neighbors) {
-                            if (((SeaTile) neighbor).getAltitude() < 0)
+                            if (((SeaTile) neighbor).isWater())
                                 seaNeighbors++;
                         }
                         //if it has at least one neighbor, 40% chance of turning into sea
@@ -216,7 +216,7 @@ public class NauticalMapFactory {
                     }
                 //remove all the marked land tiles and turn them into ocean
                 for (SeaTile toRemove : toFlip) {
-                    assert toRemove.getAltitude() >= 0; //should be removing land!
+                    assert toRemove.isLand(); //should be removing land!
                     SeaTile substitute = new SeaTile(toRemove.getGridX(), toRemove.getGridY(), -random.nextInt(5000),
                                                      new TileHabitat(0d));
                     assert baseGrid.field[toRemove.getGridX()][toRemove.getGridY()] == toRemove;
@@ -353,7 +353,7 @@ public class NauticalMapFactory {
                             int x = random.nextInt(width);
                             int y = random.nextInt(height);
                             SeaTile toChange = (SeaTile) baseGrid.get(x, y);
-                            if (toChange.getAltitude() > 0) //land is cool man
+                            if (toChange.isLand()) //land is cool man
                             {
                                 assert toChange.getBiomass(null) <= 0;
                                 continue;

--- a/src/main/java/uk/ac/ox/oxfish/geography/SeaTile.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/SeaTile.java
@@ -259,7 +259,9 @@ public class SeaTile implements Startable, LocalBiology{
         return biology.getAbundance(species);
     }
 
+    public boolean isLand() { return altitude >= 0; }
 
+    public boolean isWater() { return !isLand(); }
 
     public Port grabPortHere() {
         return portHere;

--- a/src/main/java/uk/ac/ox/oxfish/geography/discretization/MapDiscretization.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/discretization/MapDiscretization.java
@@ -72,7 +72,7 @@ public class MapDiscretization {
         groups = discretizer.discretize(map);
         //filter out all land tiles
         for (int i = 0; i < groups.length; i++) {
-            groups[i] = groups[i].stream().filter(tile -> tile.getAltitude() < 0).collect(Collectors.toList());
+            groups[i] = groups[i].stream().filter(SeaTile::isWater).collect(Collectors.toList());
             //lock changes
             groups[i] = Collections.unmodifiableList(groups[i]);
         }
@@ -125,7 +125,7 @@ public class MapDiscretization {
             return null;
         }
         assert grouped.containsKey(tile);
-        assert tile.getAltitude()<=0;
+        assert tile.isWater();
         return grouped.get(tile);
     }
 

--- a/src/main/java/uk/ac/ox/oxfish/geography/fads/FadMap.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/fads/FadMap.java
@@ -78,7 +78,7 @@ public class FadMap implements Startable, Steppable {
         driftingObjectsMap.applyDrift();
         for (Fad fad : allFads().collect(Collectors.toList())) { // use copy, as FADs can be removed
             final Optional<SeaTile> seaTile = getFadTile(fad)
-                .filter(tile -> tile.getAltitude() <= 0);
+                .filter(SeaTile::isWater);
             if (seaTile.isPresent())
                 fad.aggregateFish(seaTile.get(), globalBiology);
             else

--- a/src/main/java/uk/ac/ox/oxfish/geography/habitat/RockyPyramidsHabitatInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/habitat/RockyPyramidsHabitatInitializer.java
@@ -64,7 +64,7 @@ public class RockyPyramidsHabitatInitializer implements HabitatInitializer {
                 x = random.nextInt(mapWidth);
                 y = random.nextInt(mapHeight);
             }
-            while (map.getSeaTile(x, y).getAltitude() > 0);
+            while (map.getSeaTile(x, y).isLand());
 
 
             map.getSeaTile(x,y).setHabitat(new TileHabitat(1d));
@@ -77,7 +77,7 @@ public class RockyPyramidsHabitatInitializer implements HabitatInitializer {
                 for(int h=-spread; h<=spread; h++)
                 {
                     SeaTile border = map.getSeaTile(x-spread, y + h);
-                    if(border != null && border.getAltitude() < 0)
+                    if(border != null && border.isWater())
                     {
 
                         border.setHabitat(new TileHabitat(
@@ -88,7 +88,7 @@ public class RockyPyramidsHabitatInitializer implements HabitatInitializer {
                         ));
                     }
                     border = map.getSeaTile(x+spread, y + h);
-                    if(border != null && border.getAltitude() < 0)
+                    if(border != null && border.isWater())
                     {
                         border.setHabitat(new TileHabitat(
                                 Math.min(border.getRockyPercentage() +
@@ -104,7 +104,7 @@ public class RockyPyramidsHabitatInitializer implements HabitatInitializer {
                 for(int w=-spread+1; w<spread; w++)
                 {
                     SeaTile border = map.getSeaTile(x+w, y - spread);
-                    if(border != null && border.getAltitude() < 0)
+                    if(border != null && border.isWater())
                     {
                         border.setHabitat(new TileHabitat(
                                 Math.min( border.getRockyPercentage() + Math.pow(smoothingValue.apply(random),spread),1)
@@ -113,7 +113,7 @@ public class RockyPyramidsHabitatInitializer implements HabitatInitializer {
                         ));
                     }
                     border = map.getSeaTile(x+w, y+spread);
-                    if(border != null && border.getAltitude() < 0)
+                    if(border != null && border.isWater())
                     {
                         border.setHabitat(new TileHabitat(
                                 Math.min( border.getRockyPercentage() +

--- a/src/main/java/uk/ac/ox/oxfish/geography/habitat/rectangles/RandomRockyRectangles.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/habitat/rectangles/RandomRockyRectangles.java
@@ -70,7 +70,7 @@ public class RandomRockyRectangles implements   RockyRectangleMaker {
                 y = random.nextInt(mapHeight);
             }
             //can't be on land
-            while (map.getSeaTile(x, y).getAltitude() > 0);
+            while (map.getSeaTile(x, y).isLand());
 
 
             //get rectangle size

--- a/src/main/java/uk/ac/ox/oxfish/geography/habitat/rectangles/RockyRectanglesHabitatInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/habitat/rectangles/RockyRectanglesHabitatInitializer.java
@@ -116,7 +116,7 @@ public class RockyRectanglesHabitatInitializer implements HabitatInitializer
 
                         SeaTile tile = map.getSeaTile(x + w, y + h);
                         //if it's in the sea
-                        if(tile != null && tile.getAltitude() < 0)
+                        if(tile != null && tile.isWater())
                         {
                             //make it rocky
                             tile.setHabitat(new TileHabitat(1d));
@@ -126,10 +126,10 @@ public class RockyRectanglesHabitatInitializer implements HabitatInitializer
                 }
                 //get the border if it exists
                 SeaTile border = map.getSeaTile(x+w,y+rockyHeight);
-                if(border!= null && border.getAltitude() < 0)
+                if(border!= null && border.isWater())
                     borderTiles.add(border);
                 border = map.getSeaTile(x+w,y-1);
-                if(border!= null && border.getAltitude() < 0)
+                if(border!= null && border.isWater())
                     borderTiles.add(border);
 
             }
@@ -143,13 +143,13 @@ public class RockyRectanglesHabitatInitializer implements HabitatInitializer
                 //lower border
                 SeaTile border = map.getSeaTile(x-1, y + h);
                 //if it's in the sea
-                if(border != null && border.getAltitude() < 0)
+                if(border != null && border.isWater())
                 {
                     borderTiles.add(border);
                 }
                 //higher border
                 border = map.getSeaTile(x+rockyWidth, y + h);
-                if(border != null && border.getAltitude() < 0)
+                if(border != null && border.isWater())
                 {
                     borderTiles.add(border);
                 }

--- a/src/main/java/uk/ac/ox/oxfish/geography/mapmakers/SimpleMapInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/mapmakers/SimpleMapInitializer.java
@@ -107,7 +107,7 @@ public class SimpleMapInitializer implements MapInitializer {
                 for (int x = 0; x < width; x++)
                     for (int y = 0; y < height; y++) {
                         SeaTile tile = (SeaTile) baseGrid.field[x][y];
-                        if (tile.getAltitude() < 0)
+                        if (tile.isWater())
                             continue; //if it's ocean, don't bother
 
                         Bag neighbors = new Bag();
@@ -115,7 +115,7 @@ public class SimpleMapInitializer implements MapInitializer {
                         //count how many neighbors are ocean
                         int seaNeighbors = 0;
                         for (Object neighbor : neighbors) {
-                            if (((SeaTile) neighbor).getAltitude() < 0)
+                            if (((SeaTile) neighbor).isWater())
                                 seaNeighbors++;
                         }
                         //if it has at least one neighbor, 40% chance of turning into sea
@@ -124,7 +124,7 @@ public class SimpleMapInitializer implements MapInitializer {
                     }
                 //remove all the marked land tiles and turn them into ocean
                 for (SeaTile toRemove : toFlip) {
-                    assert toRemove.getAltitude() >= 0; //should be removing land!
+                    assert toRemove.isLand(); //should be removing land!
                     SeaTile substitute = new SeaTile(toRemove.getGridX(), toRemove.getGridY(), -random.nextInt(5000),
                                                      new TileHabitat(0d));
                     assert baseGrid.field[toRemove.getGridX()][toRemove.getGridY()] == toRemove;

--- a/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/AStarFallbackPathfinder.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/AStarFallbackPathfinder.java
@@ -39,7 +39,7 @@ public class AStarFallbackPathfinder implements Pathfinder {
         // We don't know that path, see if we can get a straight path
         final Deque<SeaTile> straightPath = straightLinePathfinder.getRoute(map, start, end);
         final boolean pathCrossesLand = straightPath.stream().anyMatch(seaTile ->
-            seaTile.getAltitude() >= 0 && !seaTile.isPortHere()
+            seaTile.isLand() && !seaTile.isPortHere()
         );
         if (!pathCrossesLand) {
             // We have a straight path across water, put it in memory and return it

--- a/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/AStarPathfinder.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/AStarPathfinder.java
@@ -117,7 +117,7 @@ public class AStarPathfinder implements Pathfinder {
             {
                 SeaTile neighbor = ((SeaTile) next);
 
-                if(neighbor.getAltitude() >= 0 && neighbor != end) //don't bother if it's land
+                if (neighbor.isLand() && neighbor != end) //don't bother if it's land
                     continue;
 
                 //check how much it would cost to move there

--- a/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/BreadthFirstPathfinder.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/BreadthFirstPathfinder.java
@@ -73,7 +73,7 @@ public class BreadthFirstPathfinder implements Pathfinder {
             for(Object next : neighbors)
             {
                 SeaTile neighbor = ((SeaTile) next);
-                if(neighbor.getAltitude() <0 && !cameFrom.containsKey(neighbor)) //ignore tiles that aren't in the sea or that we explored already
+                if(neighbor.isWater() && !cameFrom.containsKey(neighbor)) //ignore tiles that aren't in the sea or that we explored already
                 {
                     frontier.add(neighbor);
                     cameFrom.put(neighbor,current);

--- a/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/StraightLinePathfinder.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/pathfinding/StraightLinePathfinder.java
@@ -73,16 +73,16 @@ public class StraightLinePathfinder implements Pathfinder {
 
             //can you move your preferred way?
             SeaTile bestSeaTile = map.getSeaTile(candidateX, candidateY);
-            if (bestSeaTile.getAltitude() <= 0 || bestSeaTile.isPortHere()) {
+            if (bestSeaTile.isWater() || bestSeaTile.isPortHere()) {
                 path.add(bestSeaTile);
                 x = candidateX;
                 y = candidateY;
             }
             //try to move on the x axis only then
-            else if (candidateX != x && map.getSeaTile(candidateX, y).getAltitude() <= 0) {
+            else if (candidateX != x && map.getSeaTile(candidateX, y).isWater()) {
                 x = candidateX;
                 path.add(map.getSeaTile(candidateX, y));
-            } else if (candidateY != y && map.getSeaTile(x, candidateY).getAltitude() <= 0) {
+            } else if (candidateY != y && map.getSeaTile(x, candidateY).isWater()) {
                 y = candidateY;
                 path.add(map.getSeaTile(x, candidateY));
 

--- a/src/main/java/uk/ac/ox/oxfish/geography/ports/RandomPortInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/ports/RandomPortInitializer.java
@@ -77,13 +77,13 @@ public class RandomPortInitializer implements PortInitializer {
             {
 
                 SeaTile possible = (SeaTile) baseGrid.get(x, y);
-                if(possible.getAltitude() <= 0) //sea tiles aren't welcome!
+                if(possible.isWater()) //sea tiles aren't welcome!
                     continue;
                 int neighboringSeaTiles = 0;
                 Bag neighbors = new Bag();
                 baseGrid.getMooreNeighbors(x, y, 1, Grid2D.BOUNDED, false, neighbors, null, null);
                 for(Object neighbor : neighbors)
-                    if(((SeaTile)neighbor).getAltitude() < 0 )
+                    if(((SeaTile)neighbor).isWater())
                         neighboringSeaTiles++;
 
                 if(neighboringSeaTiles >=1)

--- a/src/main/java/uk/ac/ox/oxfish/gui/drawing/ColorfulGrid.java
+++ b/src/main/java/uk/ac/ox/oxfish/gui/drawing/ColorfulGrid.java
@@ -95,7 +95,7 @@ public class ColorfulGrid extends FastObjectGridPortrayal2D {
         //add the default color map showing rocky areas
         encodings.put("Habitat",new ColorEncoding(
                 new TriColorMap(-1,0,1,Color.black,new Color(237, 201, 175), new Color(69, 67, 67)),
-                seaTile -> seaTile.getAltitude() >=0 ? Double.NaN : seaTile.getRockyPercentage(),
+                seaTile -> seaTile.isLand() ? Double.NaN : seaTile.getRockyPercentage(),
                 true));
 
         setSelectedEncoding("Depth");
@@ -156,7 +156,7 @@ public class ColorfulGrid extends FastObjectGridPortrayal2D {
                         }
                     },
                     seaTile ->
-                            seaTile.getAltitude() >= 0 ? Double.NaN :
+                            seaTile.isLand() ? Double.NaN :
                             BIOMASS_TRANSFORM.apply(
                                     seaTile.getBiomass(species)),
                     false,

--- a/src/main/java/uk/ac/ox/oxfish/model/data/collectors/TowHeatmapGatherer.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/data/collectors/TowHeatmapGatherer.java
@@ -75,7 +75,7 @@ public class TowHeatmapGatherer implements Steppable, Startable{
             for (int x = 0; x < model.getMap().getWidth(); x++)
                 for (int y = 0; y < model.getMap().getHeight(); y++)
                 {
-                    if(model.getMap().getSeaTile(x,y).getAltitude()>0)
+                    if(model.getMap().getSeaTile(x,y).isLand())
                         towHeatmap[x][model.getMap().getHeight() - y - 1] = Double.NaN;
                     else
                         towHeatmap[x][model.getMap().getHeight() - y - 1] += trawls.get(x, y);

--- a/src/main/java/uk/ac/ox/oxfish/model/scenario/CaliforniaAbstractScenario.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/scenario/CaliforniaAbstractScenario.java
@@ -443,7 +443,7 @@ public abstract class CaliforniaAbstractScenario implements Scenario {
                             getBiologyInitializer()
                                     .generateLocal(biology, seaTile, model.getRandom(), gridHeight, gridWidth,map ));
                     //if it's sea (don't bother counting otherwise)
-                    if (seaTile.getAltitude() < 0)
+                    if (seaTile.isWater())
                     {
                         int i = 0;
                         //each specie grid value is an ObjectGrid2D whose cells are themselves list of observations

--- a/src/main/java/uk/ac/ox/oxfish/utility/adaptation/maximization/DefaultBeamHillClimbing.java
+++ b/src/main/java/uk/ac/ox/oxfish/utility/adaptation/maximization/DefaultBeamHillClimbing.java
@@ -49,7 +49,7 @@ public class DefaultBeamHillClimbing extends BeamHillClimbing<SeaTile> {
                     int x = current.getGridX() + (random.nextBoolean() ? random.nextInt(maxStep+1) : -random.nextInt(maxStep+1));
                     int y = current.getGridY() + (random.nextBoolean() ? random.nextInt(maxStep+1) : -random.nextInt(maxStep+1));
                     SeaTile candidate = state.getMap().getSeaTile(x,y);
-                    if(candidate!=null && current!= candidate && candidate.getAltitude()<0
+                    if(candidate!=null && current!= candidate && candidate.isWater()
                             &&!fisher.getHomePort().getLocation().equals(candidate) )
                         return candidate;
                 }

--- a/src/main/java/uk/ac/ox/oxfish/utility/parameters/PortReader.java
+++ b/src/main/java/uk/ac/ox/oxfish/utility/parameters/PortReader.java
@@ -129,10 +129,10 @@ public class PortReader {
      */
     public static boolean isCorrectLocationForPort(SeaTile tile, NauticalMap map)
     {
-        if(tile.getAltitude()>=0)
+        if(tile.isLand())
         {
             LinkedList<SeaTile> neighbors = new LinkedList<SeaTile>(map.getMooreNeighbors(tile, 1));
-            return neighbors.stream().anyMatch(seaTile -> seaTile.getAltitude()<0);
+            return neighbors.stream().anyMatch(SeaTile::isWater);
         }
 
         return false;

--- a/src/test/java/uk/ac/ox/oxfish/fisher/strategies/RandomThenBackToPortDestinationStrategyTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/strategies/RandomThenBackToPortDestinationStrategyTest.java
@@ -81,7 +81,7 @@ public class RandomThenBackToPortDestinationStrategyTest {
             SeaTile destination = strategy.chooseDestination(fisher,
                                                              random, model, action);
             assertEquals(destination.getGridX(),0);
-            assertTrue(destination.getAltitude() < 0);
+            assertTrue(destination.isWater());
         }
 
 

--- a/src/test/java/uk/ac/ox/oxfish/fisher/strategies/destination/HeatmapDestinationStrategyTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/strategies/destination/HeatmapDestinationStrategyTest.java
@@ -66,7 +66,7 @@ public class HeatmapDestinationStrategyTest {
                 new HourlyProfitInTripObjective(true));
         SeaTile optimal = mock(SeaTile.class);
 
-        when(optimal.getAltitude()).thenReturn(-100d);
+        when(optimal.isWater()).thenReturn(true);
         when(optimizer.pick(any(), any(), any(),any(),any() )).thenReturn(optimal);
 
         strategy.start(model,user);
@@ -112,7 +112,7 @@ public class HeatmapDestinationStrategyTest {
                 new HourlyProfitInTripObjective(true));
         SeaTile optimal = mock(SeaTile.class);
 
-        when(optimal.getAltitude()).thenReturn(-100d);
+        when(optimal.isWater()).thenReturn(true);
         when(optimizer.pick(any(), any(), any(),any(),any() )).thenReturn(optimal);
 
         strategy.start(model,user);
@@ -161,7 +161,7 @@ public class HeatmapDestinationStrategyTest {
         SeaTile optimal = mock(SeaTile.class);
         assertNotEquals(strategy.getFavoriteSpot(),
                         optimal);
-        when(optimal.getAltitude()).thenReturn(-100d);
+        when(optimal.isWater()).thenReturn(true);
         when(optimizer.pick(any(), any(), any(),any(),any() )).thenReturn(optimal);
         strategy.reactToFinishedTrip(mock(TripRecord.class,RETURNS_DEEP_STUBS));
         assertEquals(strategy.getFavoriteSpot(),

--- a/src/test/java/uk/ac/ox/oxfish/fisher/strategies/destination/SNALSARDestinationStrategyTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/strategies/destination/SNALSARDestinationStrategyTest.java
@@ -77,8 +77,8 @@ public class SNALSARDestinationStrategyTest {
         FishState model = mock(FishState.class, RETURNS_DEEP_STUBS);
         when(model.getRandom()).thenReturn(new MersenneTwisterFast());
         SNALSARDestinationStrategy strategy = factory.apply(model);
-        SeaTile option1 = mock(SeaTile.class); when(option1.getAltitude()).thenReturn(-100d);
-        SeaTile option2 = mock(SeaTile.class);when(option2.getAltitude()).thenReturn(-100d);
+        SeaTile option1 = mock(SeaTile.class); when(option1.isWater()).thenReturn(true);
+        SeaTile option2 = mock(SeaTile.class); when(option2.isWater()).thenReturn(true);
         ArrayList<SeaTile> options = Lists.newArrayList(option1, option2);
 
         defaultSetup(model, strategy,options);
@@ -111,8 +111,8 @@ public class SNALSARDestinationStrategyTest {
         FishState model = mock(FishState.class, RETURNS_DEEP_STUBS);
         when(model.getRandom()).thenReturn(new MersenneTwisterFast());
         SNALSARDestinationStrategy strategy = factory.apply(model);
-        SeaTile option1 = mock(SeaTile.class); when(option1.getAltitude()).thenReturn(-100d);
-        SeaTile option2 = mock(SeaTile.class);when(option2.getAltitude()).thenReturn(-100d);
+        SeaTile option1 = mock(SeaTile.class); when(option1.isWater()).thenReturn(true);
+        SeaTile option2 = mock(SeaTile.class); when(option2.isWater()).thenReturn(true);
         ArrayList<SeaTile> options = Lists.newArrayList(option1, option2);
         FeatureExtractors extractors = defaultSetup(model, strategy,options);
 
@@ -156,9 +156,9 @@ public class SNALSARDestinationStrategyTest {
         FishState model = mock(FishState.class, RETURNS_DEEP_STUBS);
         when(model.getRandom()).thenReturn(new MersenneTwisterFast());
         SNALSARDestinationStrategy strategy = factory.apply(model);
-        SeaTile option1 = mock(SeaTile.class); when(option1.getAltitude()).thenReturn(-100d);
-        SeaTile option2 = mock(SeaTile.class);when(option2.getAltitude()).thenReturn(-100d);
-        SeaTile option3 = mock(SeaTile.class);when(option3.getAltitude()).thenReturn(-100d);
+        SeaTile option1 = mock(SeaTile.class); when(option1.isWater()).thenReturn(true);
+        SeaTile option2 = mock(SeaTile.class); when(option2.isWater()).thenReturn(true);
+        SeaTile option3 = mock(SeaTile.class); when(option3.isWater()).thenReturn(true);
         ArrayList<SeaTile> options = Lists.newArrayList(option1, option2,option3);
         FeatureExtractors extractors = defaultSetup(model, strategy,options);
 
@@ -212,8 +212,8 @@ public class SNALSARDestinationStrategyTest {
         when(model.getRandom()).thenReturn(new MersenneTwisterFast());
         SNALSARDestinationStrategy strategy = factory.apply(model);
 
-        SeaTile option1 = mock(SeaTile.class); when(option1.getAltitude()).thenReturn(-100d);
-        SeaTile option2 = mock(SeaTile.class);when(option2.getAltitude()).thenReturn(-100d);
+        SeaTile option1 = mock(SeaTile.class); when(option1.isWater()).thenReturn(true);
+        SeaTile option2 = mock(SeaTile.class); when(option2.isWater()).thenReturn(true);
         ArrayList<SeaTile> options = Lists.newArrayList(option1, option2);
 
         FeatureExtractors extractors = defaultSetup(model, strategy,options);


### PR DESCRIPTION
...and use them instead in various places where `SeaTile::getAltitude` results where compared to zero.

Two rationales for that:

- it makes the code more readable;
- it offloads the task of remembering if the right condition is `getAltitude() > 0` or `getAltitude() >= 0` to the methods.

That last one is the biggie for me. I could never remember which one to use and, as can be seen in the diffs, the old code wasn't always consistent either.

Regarding my changes:

- Where old code used `getAltitude >= 0` or `getAltitude < 0`, replacing these checks with the new methods shouldn't change behaviour.
- Where old code used `getAltitude > 0` or `getAltitude <= 0`, I made a judgement call, but mostly replaced the old calls. The only ones I've left in place are:

	```
	$ git grep -E 'getAltitude\(\) ?(>|<=|>=|<) ?0'
	src/main/java/uk/ac/ox/oxfish/biology/initializer/allocator/DepthAllocatorDecorator.java:                tile.getAltitude()<=0 &&
	src/main/java/uk/ac/ox/oxfish/geography/NauticalMapFactory.java:            if(newAltitude <0 && toChange.getAltitude() > 0)
	src/main/java/uk/ac/ox/oxfish/geography/NauticalMapFactory.java:            if(newAltitude >0 && toChange.getAltitude() < 0)
	src/main/java/uk/ac/ox/oxfish/geography/NauticalMapFactory.java:            if (seaTile.getAltitude() > 0)
	src/main/java/uk/ac/ox/oxfish/geography/mapmakers/SimpleMapInitializer.java:            if(newAltitude <0 && toChange.getAltitude() > 0)
	src/main/java/uk/ac/ox/oxfish/geography/mapmakers/SimpleMapInitializer.java:            if(newAltitude >0 && toChange.getAltitude() < 0)
	```

- I also had to change a few tests that where mocking `getAltitude()` to fake water tiles.

What could go wrong with the changes I did make?

If there was a place that relied on a tile with altitude equal to exactly zero being interpreted as water instead of land, we'd have a problem. That seems unlikely to me, but @CarrKnight, please let me know if you think otherwise.