### PR TITLE
explicitely request Ubuntu Trusty distribution in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 install: true
-
+dist: trusty
 
 script:
 - ./gradlew build --scan -s


### PR DESCRIPTION
Travis CI has [changed its default build environment from Ubuntu Trusty to Ubuntu Xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment).

The default JDK in xenial is OpenJDK 11, under which POSEIDON does not currently compile.

The Oracle JDK 8 fails to install under Travis' xenial environment, [apparently because of changes in Oracle's licensing policy](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038).

We could use Open JDK 8, but JavaFX isn't bundled with it. (POSEIDON uses JavaFX for its observable collections.) There is [a Gradle plugin](https://openjfx.io/openjfx-docs/#gradle) to use JavaFX with Open JDK, but I wasn't able to get it to work with Open JDK 8 in the short amount of time I spent on this.

The easy solution for now is just to force Travis to stay on trusty, and thus keep the Oracle JDK 8 as the default JDK.

The cleaner, long-term solution will be to update POSEIDON to compile on OpenJDK 11. I'm quite keen on trying this out and might give it a shot in the nearish future.