### PR TITLE
Avoid generating empty tag in fisher definition...

### DIFF
--- a/src/main/java/uk/ac/ox/oxfish/fisher/Fisher.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/Fisher.java
@@ -66,6 +66,8 @@ import uk.ac.ox.oxfish.utility.adaptation.AdaptationPerTripScheduler;
 
 import java.util.*;
 
+import static java.util.stream.Collectors.joining;
+
 /**
  * The boat catching all that delicious fish.
  * At its core it is a discrete-state automata: the Action class represents a possible state and the fisher can go through
@@ -1034,7 +1036,7 @@ public class Fisher implements Steppable, Startable{
 
     @Override
     public String toString() {
-        return "Fisher " + fisherID +"; " + getTags().stream().reduce((s, s2) -> s+" - "+s2);
+        return "Fisher " + fisherID + "; " + getTags().stream().collect(joining(" - "));
     }
 
     /**

--- a/src/main/java/uk/ac/ox/oxfish/model/scenario/FisherDefinition.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/scenario/FisherDefinition.java
@@ -21,6 +21,7 @@
 package uk.ac.ox.oxfish.model.scenario;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import ec.util.MersenneTwisterFast;
 import uk.ac.ox.oxfish.biology.GlobalBiology;
 import uk.ac.ox.oxfish.fisher.Fisher;
@@ -306,17 +307,8 @@ public class FisherDefinition {
         );
 
         //add tags to fisher definition
-        final String[] tags = this.tags.split(",");
-        if(tags.length>0)
-            fisherFactory.getAdditionalSetups().add(
-                    new Consumer<Fisher>() {
-                        @Override
-                        public void accept(Fisher fisher) {
-                            for(String tag : tags)
-                                fisher.getTags().add(tag.trim());
-                        }
-                    }
-            );
+        final List<String> tags = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(this.tags);
+        if (!tags.isEmpty()) fisherFactory.getAdditionalSetups().add(fisher -> fisher.getTags().addAll(tags));
 
         //add other setups
         fisherFactory.getAdditionalSetups().addAll(additionalSetups);


### PR DESCRIPTION
...and avoid showing `Optional[]` when listing tags in the `Fisher.toString` method.