### PR TITLE
Update Gradle to version 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,14 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.1.0'
 }
 
-
-
-mainClassName = 'uk.ac.ox.oxfish.Main'
+application {
+    mainClassName = 'uk.ac.ox.oxfish.Main'
+    applicationDefaultJvmArgs = ["-Xms1024m", "-Xmx2048m"]
+}
 
 repositories {
     mavenLocal()
     mavenCentral()
-
 }
 
 sourceSets

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ plugins {
     //id "us.kirchmeier.capsule" version "1.0.1"
     //id "jacoco"
     id 'com.github.johnrengelman.shadow' version '5.1.0'
-    id "com.gradle.build-scan" version "3.0"
-
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,9 @@ dependencies
 
 //this makes tests multi-threaded when called from gradle. Useful!
 test{
-        maxParallelForks = Math.min(Runtime.runtime.availableProcessors(),3)
+    minHeapSize = "2048m"
+    maxHeapSize = "2048m"
+    maxParallelForks = Math.min(Runtime.runtime.availableProcessors(),3)
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx2048M -Xms2048M
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -97,7 +97,7 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
     fi
 else
-    JAVACMD="/usr/lib/jvm/java-11-openjdk/bin/java"
+    JAVACMD="java"
     which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.gradle.enterprise" version "3.0"
+}


### PR DESCRIPTION
This should hopefully be the final required step to get POSEIDON to compile on OpenJDK 8, 11 and 13.

Had to upgrade the gradle scan plugin to the enterprise version and manually set memory options in tests to make sure tests they pass. I've also set memory for the application itself.

The `gradlew` script modification is from Gradle itself, and should allow building with OpenJDK 13 on MacOS when the `$JAVA_HOME` variable is not set (e.g., on @jenskoedmadsen's machine).