### PR TITLE
fix "tooFewBins" test

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -1,5 +1,5 @@
 name: Spotbugs
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     name: Spotbugs

--- a/src/test/java/uk/ac/ox/oxfish/biology/initializer/factory/SingleSpeciesBoxcarFromListFactoryTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/biology/initializer/factory/SingleSpeciesBoxcarFromListFactoryTest.java
@@ -2,8 +2,11 @@ package uk.ac.ox.oxfish.biology.initializer.factory;
 
 import ec.util.MersenneTwisterFast;
 import org.jetbrains.annotations.NotNull;
+import org.jfree.util.Log;
+import org.jfree.util.LogTarget;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
+import org.mockito.ArgumentCaptor;
 import uk.ac.ox.oxfish.biology.GlobalBiology;
 import uk.ac.ox.oxfish.biology.initializer.SingleSpeciesAbundanceInitializer;
 import uk.ac.ox.oxfish.model.FishState;
@@ -14,7 +17,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SingleSpeciesBoxcarFromListFactoryTest {
@@ -43,17 +48,18 @@ public class SingleSpeciesBoxcarFromListFactoryTest {
     @Test
     public void tooFewBins() {
 
+        // Add a fake logger
+        final LogTarget logTarget = mock(LogTarget.class);
+        Log.getInstance().addTarget(logTarget);
 
-        //puts in the population we put out
-        double[] populationArray = {1000.6980456204348, 6.121015839632853};
-        assertThrows(IllegalArgumentException.class,
-                new ThrowingRunnable() {
-                    @Override
-                    public void run() throws Throwable {
-                        buildPopulation(populationArray);
-                    }
-                }
-        );
+        final double[] populationArray = new double[20];
+        buildPopulation(populationArray);
+
+        final ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(logTarget).log(anyInt(), captor.capture());
+        assertTrue(captor.getAllValues().contains(
+            "The number of bins provided given their width won't reach l-infinity..."
+        ));
 
     }
 

--- a/src/test/java/uk/ac/ox/oxfish/biology/initializer/factory/SingleSpeciesBoxcarFromListFactoryTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/biology/initializer/factory/SingleSpeciesBoxcarFromListFactoryTest.java
@@ -1,26 +1,26 @@
 package uk.ac.ox.oxfish.biology.initializer.factory;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import ec.util.MersenneTwisterFast;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jfree.util.Log;
 import org.jfree.util.LogTarget;
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.mockito.ArgumentCaptor;
 import uk.ac.ox.oxfish.biology.GlobalBiology;
 import uk.ac.ox.oxfish.biology.initializer.SingleSpeciesAbundanceInitializer;
 import uk.ac.ox.oxfish.model.FishState;
 import uk.ac.ox.oxfish.utility.parameters.FixedDoubleParameter;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class SingleSpeciesBoxcarFromListFactoryTest {
 
@@ -52,8 +52,12 @@ public class SingleSpeciesBoxcarFromListFactoryTest {
         final LogTarget logTarget = mock(LogTarget.class);
         Log.getInstance().addTarget(logTarget);
 
-        final double[] populationArray = new double[20];
-        buildPopulation(populationArray);
+        final double[] populationArray = new double[2];
+        assertThrows(
+            "bins do not reach even half of L_infinity. The biology is inconsistent!",
+            IllegalArgumentException.class,
+            () -> buildPopulation(populationArray)
+        );
 
         final ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         verify(logTarget).log(anyInt(), captor.capture());


### PR DESCRIPTION
This test was broken in 3bcd9b3170a1894117058372d67c87fe65a4fede.

The exception was changed to a logged warning, so I had to capture the
logger output to test it. I also had to change the number of bins to get
the message to occur. Not entirely sure that was the right approach,
though. @CarrKnight might want to have a look.