### PR TITLE
Don't run spotbugs on pull requests

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -1,5 +1,5 @@
 name: Spotbugs
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     name: Spotbugs


### PR DESCRIPTION
as it fails there with:
Error: HttpError: Resource not accessible by integration

There's something about the way github pull_request actions work
that Spotbugs doesn't play well with. It doesn't really matter
for us anyway.