### PR TITLE
Update EPO inputs + put FADs back in inventory after set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ distZip { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
 //this makes tests multi-threaded when called from gradle. Useful!
 test {
     minHeapSize = "1024m"
-    maxHeapSize = "6G" // GitHub actions gives us 7G memory, so this should be safe for running online tests
+    maxHeapSize = "4G" // GitHub actions was crashing on 6GB, let's see if 4GB fixes it...
     maxParallelForks = Math.min(Runtime.runtime.availableProcessors(), 8)
 }
 

--- a/inputs/tests/tunabacksliding/base_scenario.yaml
+++ b/inputs/tests/tunabacksliding/base_scenario.yaml
@@ -1,7 +1,10 @@
 EPO Abundance Pathfinding:
+  gearStrategy:
+    FAD Refill:
+      maxFadDeploymentsFile: inputs/epo_inputs/tests/backsliding/max_deployments.csv
   abundanceCatchSamplersFactory:
     abundanceFilters: null
-    catchSamplesFile: inputs/epo_inputs/set_samples.csv
+    catchSamplesFile: inputs/epo_inputs/tests/backsliding/set_samples.csv
   abundanceFiltersFactory:
     selectivityFilePath: inputs/epo_inputs/abundance/selectivity.csv
   abundanceInitializerFactory:
@@ -47,7 +50,7 @@ EPO Abundance Pathfinding:
     fadInitializerFactory: null
     fadSetObservers: !!set {
       }
-    locationValuesFile: inputs/epo_inputs/location_values.csv
+    locationValuesFile: inputs/epo_inputs/tests/backsliding/location_values.csv
     nonAssociatedSetObservers: !!set {
       }
     nonAssociatedSetTimeSinceLastVisitModulationFunction:
@@ -93,7 +96,7 @@ EPO Abundance Pathfinding:
     attractionWeightsFile: inputs/epo_inputs/location_values.csv
     catchSamplersFactory: !!uk.ac.ox.oxfish.fisher.purseseiner.samplers.AbundanceCatchSamplersFactory
       abundanceFilters: null
-      catchSamplesFile: inputs/epo_inputs/set_samples.csv
+      catchSamplesFile: inputs/epo_inputs/tests/backsliding/set_samples.csv
     deploymentBias: '1.0'
     distancePenaltyFadSets: '1.0'
     hoursWastedOnFailedSearches: '20.0'
@@ -101,7 +104,7 @@ EPO Abundance Pathfinding:
       Squared Discretization:
         horizontalSplits: '5'
         verticalSplits: '3'
-    maxTripDurationFile: inputs/epo_inputs/boats.csv
+    maxTripDurationFile: inputs/epo_inputs/tests/backsliding/boats.csv
     minimumValueFadSets: '5000.0'
     minimumValueOpportunisticFadSets: '5000.0'
     ownFadActionWeightBias: '1.0'
@@ -188,4 +191,4 @@ EPO Abundance Pathfinding:
     recruitmentProcesses: null
   zapper: true
   zapperAge: false
-  vesselsFilePath: inputs/epo_inputs/boats.csv
+  vesselsFilePath: inputs/epo_inputs/tests/backsliding/boats.csv

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/PurseSeineVesselReader.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/PurseSeineVesselReader.java
@@ -132,7 +132,7 @@ public class PurseSeineVesselReader implements AlgorithmFactory<List<Fisher>> {
                     holdVolume,
                     fishState.getBiology()
                 ));
-                final String boatId = record.getString("boat_id");
+                final String boatId = record.getString("ves_no");
                 final Fisher fisher = fisherFactory.buildFisher(fishState);
                 fisher.getTags().add(boatId);
                 setFixedRestTime(

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/actions/AbstractFadSetAction.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/actions/AbstractFadSetAction.java
@@ -19,11 +19,12 @@
 
 package uk.ac.ox.oxfish.fisher.purseseiner.actions;
 
+import static uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager.getFadManager;
+
 import uk.ac.ox.oxfish.biology.LocalBiology;
 import uk.ac.ox.oxfish.fisher.Fisher;
 import uk.ac.ox.oxfish.fisher.purseseiner.equipment.PurseSeineGear;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.AbstractFad;
-import uk.ac.ox.oxfish.fisher.purseseiner.fads.Fad;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager;
 import uk.ac.ox.oxfish.geography.SeaTile;
 import uk.ac.ox.oxfish.model.FishState;
@@ -59,10 +60,10 @@ public abstract class AbstractFadSetAction<B extends LocalBiology, F extends Abs
 
     @Override
     public void reactToSuccessfulSet(final FishState fishState, final SeaTile locationOfSet) {
-        fad.reactToBeingFished(fishState,getFisher(),locationOfSet);
+        fad.reactToBeingFished(fishState, getFisher(), locationOfSet);
         // Nothing to do here since the biomass has already been removed from the ocean
         fishState.getFadMap().destroyFad(fad);
-
+        getFadManager(getFisher()).putFadBackInStock();
     }
 
     /**
@@ -72,7 +73,7 @@ public abstract class AbstractFadSetAction<B extends LocalBiology, F extends Abs
     public void reactToFailedSet(final FishState fishState, final SeaTile locationOfSet) {
         fad.releaseFish(fishState.getBiology().getSpecies(), locationOfSet.getBiology());
         fishState.getFadMap().destroyFad(fad);
-
+        getFadManager(getFisher()).putFadBackInStock();
     }
 
     @Override

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/actions/FadSetAction.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/actions/FadSetAction.java
@@ -26,7 +26,6 @@ import uk.ac.ox.oxfish.biology.LocalBiology;
 import uk.ac.ox.oxfish.fisher.Fisher;
 import uk.ac.ox.oxfish.fisher.actions.ActionResult;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.AbstractFad;
-import uk.ac.ox.oxfish.fisher.purseseiner.fads.Fad;
 import uk.ac.ox.oxfish.model.FishState;
 import uk.ac.ox.oxfish.model.regs.Regulation;
 

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/ActionWeightsCache.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/ActionWeightsCache.java
@@ -42,7 +42,7 @@ public class ActionWeightsCache extends FisherValuesByActionFromFileCache<Double
                 groupingBy(
                     record -> record.getInt("year"),
                     groupingBy(
-                        record -> record.getString("boat_id"),
+                        record -> record.getString("ves_no"),
                         toMap(
                             record -> ActionClass.valueOf(record.getString("event")).getActionClass(),
                             record -> record.getDouble("w")

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/LocationFisherValuesByActionCache.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/LocationFisherValuesByActionCache.java
@@ -50,7 +50,7 @@ public class LocationFisherValuesByActionCache extends FisherValuesByActionFromF
                 groupingBy(
                     record -> record.getInt("year"),
                     groupingBy(
-                        record -> record.getString("boat_id"),
+                        record -> record.getString("ves_no"),
                         groupingBy(
                             record -> ActionClass.valueOf(record.getString("event")).getActionClass(),
                             toMap(

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManager.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManager.java
@@ -296,4 +296,10 @@ public class FadManager<B extends LocalBiology, F extends AbstractFad<B, F>> {
 
     }
 
+    /**
+     * Increments the number of FADs in stock by one.
+     */
+    public void putFadBackInStock() {
+        numFadsInStock++;
+    }
 }

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/destination/GravityDestinationStrategyFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/destination/GravityDestinationStrategyFactory.java
@@ -53,7 +53,7 @@ public class GravityDestinationStrategyFactory
                     groupingBy(
                         record -> record.getInt("year"),
                         toMap(
-                            record -> record.getString("boat_id"),
+                            record -> record.getString("ves_no"),
                             record -> record.getDouble("max_trip_duration_in_hours")
                         )
                     ));

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/gear/FadRefillGearStrategy.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/gear/FadRefillGearStrategy.java
@@ -18,18 +18,18 @@
 
 package uk.ac.ox.oxfish.fisher.purseseiner.strategies.gear;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager.getFadManager;
+import static uk.ac.ox.oxfish.model.scenario.EpoBiomassScenario.getBoatId;
+
 import com.google.common.collect.ImmutableMap;
 import ec.util.MersenneTwisterFast;
+import java.util.Map;
 import uk.ac.ox.oxfish.fisher.Fisher;
 import uk.ac.ox.oxfish.fisher.actions.Action;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager;
 import uk.ac.ox.oxfish.fisher.strategies.gear.GearStrategy;
 import uk.ac.ox.oxfish.model.FishState;
-
-import java.util.Map;
-
-import static uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager.getFadManager;
-import static uk.ac.ox.oxfish.model.scenario.EpoBiomassScenario.getBoatId;
 
 public class FadRefillGearStrategy implements GearStrategy {
 
@@ -48,8 +48,12 @@ public class FadRefillGearStrategy implements GearStrategy {
         final FishState model,
         final Action currentAction
     ) {
-        final FadManager fadManager = getFadManager(fisher);
-        final int maxFads = maxFadsPerFisher.get(getBoatId(fisher));
+        final FadManager<?, ?> fadManager = getFadManager(fisher);
+        final String boatId = getBoatId(fisher);
+        final int maxFads = checkNotNull(
+            maxFadsPerFisher.get(boatId),
+            "Max number of FADs not found for fisher %s", boatId
+        );
         // The very first time this method is called, at the start of the
         // simulation, the current trip isn't initialized yet,so we can't
         // charge the vessels for FADs, but that's fine with us since

--- a/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/gear/FadRefillGearStrategyFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/fisher/purseseiner/strategies/gear/FadRefillGearStrategyFactory.java
@@ -19,11 +19,13 @@
 package uk.ac.ox.oxfish.fisher.purseseiner.strategies.gear;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.stream.Collectors.groupingBy;
 import static uk.ac.ox.oxfish.utility.csv.CsvParserUtil.parseAllRecords;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -35,10 +37,20 @@ import uk.ac.ox.oxfish.utility.AlgorithmFactory;
 public class FadRefillGearStrategyFactory implements AlgorithmFactory<GearStrategy> {
 
     private Path maxFadDeploymentsFile = EpoScenario.INPUT_PATH.resolve("max_deployments.csv");
-    private final LoadingCache<Path, Map<String, Integer>> cache =
+    private final LoadingCache<Path, Map<Integer, ImmutableMap<String, Integer>>> cache =
         CacheBuilder.newBuilder().build(CacheLoader.from(this::readValues));
-
+    private int targetYear = EpoScenario.TARGET_YEAR;
     private double fadCost = 1000;
+
+    @SuppressWarnings("unused")
+    public int getTargetYear() {
+        return targetYear;
+    }
+
+    @SuppressWarnings("unused")
+    public void setTargetYear(final int targetYear) {
+        this.targetYear = targetYear;
+    }
 
     @SuppressWarnings("unused")
     public double getFadCost() {
@@ -50,13 +62,18 @@ public class FadRefillGearStrategyFactory implements AlgorithmFactory<GearStrate
         this.fadCost = fadCost;
     }
 
-    private Map<String, Integer> readValues() {
+    private Map<Integer, ImmutableMap<String, Integer>> readValues() {
         return parseAllRecords(maxFadDeploymentsFile)
             .stream()
-            .collect(toImmutableMap(
-                record -> record.getString("boat_id"),
-                record -> record.getInt("max_deployments")
-            ));
+            .collect(
+                groupingBy(
+                    record -> record.getInt("year"),
+                    toImmutableMap(
+                        record -> record.getString("ves_no"),
+                        record -> record.getInt("max_deployments")
+                    )
+                )
+            );
     }
 
     @SuppressWarnings("unused")
@@ -71,7 +88,10 @@ public class FadRefillGearStrategyFactory implements AlgorithmFactory<GearStrate
     @Override
     public GearStrategy apply(final FishState fishState) {
         try {
-            return new FadRefillGearStrategy(cache.get(maxFadDeploymentsFile), fadCost);
+            return new FadRefillGearStrategy(
+                cache.get(maxFadDeploymentsFile).get(targetYear),
+                fadCost
+            );
         } catch (final ExecutionException e) {
             throw new IllegalStateException(e);
         }

--- a/src/main/java/uk/ac/ox/oxfish/geography/fads/AbstractFadInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/fads/AbstractFadInitializer.java
@@ -84,7 +84,7 @@ public abstract class AbstractFadInitializer<B extends LocalBiology, F extends F
     @Override
     public F makeFad(@NotNull final FadManager<B, F> fadManager,
                      Fisher owner,
-                     SeaTile initialLocation) {
+                     @NotNull SeaTile initialLocation) {
         return makeFad(
             fadManager,
             makeBiology(biology),

--- a/src/main/java/uk/ac/ox/oxfish/geography/fads/FadInitializer.java
+++ b/src/main/java/uk/ac/ox/oxfish/geography/fads/FadInitializer.java
@@ -5,16 +5,16 @@ import org.jetbrains.annotations.Nullable;
 import uk.ac.ox.oxfish.biology.LocalBiology;
 import uk.ac.ox.oxfish.fisher.Fisher;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.AbstractFad;
-import uk.ac.ox.oxfish.fisher.purseseiner.fads.Fad;
 import uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager;
 import uk.ac.ox.oxfish.geography.SeaTile;
 
+@FunctionalInterface
 public interface FadInitializer<B extends LocalBiology, F extends AbstractFad<B, F>> {
 
-
-    public F makeFad(@NotNull final FadManager<B, F> fadManager,
-                     @Nullable Fisher owner,
-                     @NotNull SeaTile initialLocation);
-
+    public F makeFad(
+        @NotNull final FadManager<B, F> fadManager,
+        @Nullable Fisher owner,
+        @NotNull SeaTile initialLocation
+    );
 
 }

--- a/src/main/java/uk/ac/ox/oxfish/model/data/monitors/loggers/PurseSeineActionsLogger.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/data/monitors/loggers/PurseSeineActionsLogger.java
@@ -46,7 +46,7 @@ import uk.ac.ox.oxfish.model.data.monitors.observers.PurseSeinerActionObserver;
 public class PurseSeineActionsLogger implements AdditionalStartable, RowProvider {
 
     private static final List<String> HEADERS = ImmutableList.of(
-        "boat_id",
+        "ves_no",
         "action_type",
         "lon",
         "lat",

--- a/src/main/java/uk/ac/ox/oxfish/model/data/monitors/loggers/TidyFisherYearlyData.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/data/monitors/loggers/TidyFisherYearlyData.java
@@ -30,7 +30,7 @@ import static java.lang.Math.toIntExact;
 
 public class TidyFisherYearlyData extends TidyTimeSeries<TimeSeries<Fisher>> {
 
-    private static final List<String> HEADERS = ImmutableList.of("boat_id", "year", "variable", "value", "unit");
+    private static final List<String> HEADERS = ImmutableList.of("ves_no", "year", "variable", "value", "unit");
     private final String boatId;
 
     public TidyFisherYearlyData(final TimeSeries<Fisher> fisherYearlyData, final String boatId) {

--- a/src/main/java/uk/ac/ox/oxfish/model/scenario/EpoScenario.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/scenario/EpoScenario.java
@@ -88,13 +88,14 @@ public abstract class EpoScenario<B extends LocalBiology, F extends Fad<B, F>>
             //.put(EL_NINO, input("currents_el_nino.csv"))
             //.put(LA_NINA, input("currents_la_nina.csv"))
             .build();
-    private final FadRefillGearStrategyFactory gearStrategy = new FadRefillGearStrategyFactory();
+    private FadRefillGearStrategyFactory gearStrategy = new FadRefillGearStrategyFactory();
     private AlgorithmFactory<? extends FishingStrategy> fishingStrategyFactory;
     private Path vesselsFilePath = INPUT_PATH.resolve("boats.csv");
     private Path costsFile = INPUT_PATH.resolve("costs.csv");
     private Path attractionWeightsFile = INPUT_PATH.resolve("action_weights.csv");
     private Path locationValuesFilePath = INPUT_PATH.resolve("location_values.csv");
-    private CatchSamplersFactory<? extends LocalBiology> catchSamplersFactory = new AbundanceCatchSamplersFactory();
+    private CatchSamplersFactory<? extends LocalBiology> catchSamplersFactory =
+        new AbundanceCatchSamplersFactory();
     private PurseSeineGearFactory<B, F> purseSeineGearFactory;
 
     @Override
@@ -106,9 +107,12 @@ public abstract class EpoScenario<B extends LocalBiology, F extends Fad<B, F>>
         final Monitors monitors = new Monitors(fishState);
         monitors.getMonitors().forEach(fishState::registerStartable);
 
-        if (getFishingStrategyFactory() != null && getFishingStrategyFactory() instanceof PurseSeinerFishingStrategyFactory) {
-            ((PurseSeinerFishingStrategyFactory<B, ?>) getFishingStrategyFactory()).setCatchSamplersFactory(getCatchSamplersFactory());
-            ((PurseSeinerFishingStrategyFactory<?, ?>) getFishingStrategyFactory()).setAttractionWeightsFile(getAttractionWeightsFile());
+        if (getFishingStrategyFactory() != null
+            && getFishingStrategyFactory() instanceof PurseSeinerFishingStrategyFactory) {
+            ((PurseSeinerFishingStrategyFactory<B, ?>) getFishingStrategyFactory()).setCatchSamplersFactory(
+                getCatchSamplersFactory());
+            ((PurseSeinerFishingStrategyFactory<?, ?>) getFishingStrategyFactory()).setAttractionWeightsFile(
+                getAttractionWeightsFile());
         }
 
         if (getPurseSeineGearFactory() != null) {
@@ -189,67 +193,68 @@ public abstract class EpoScenario<B extends LocalBiology, F extends Fad<B, F>>
         final GravityDestinationStrategyFactory gravityDestinationStrategyFactory
     ) {
         return makeFisherFactory(
-                fishState,
-                regulationsFactory,
-                purseSeineGearFactory,
-                gravityDestinationStrategyFactory,
-                fishingStrategyFactory,
-                new PurseSeinerDepartingStrategyFactory()
+            fishState,
+            regulationsFactory,
+            purseSeineGearFactory,
+            gravityDestinationStrategyFactory,
+            fishingStrategyFactory,
+            new PurseSeinerDepartingStrategyFactory()
         );
 
     }
 
-    @NotNull    FisherFactory makeFisherFactory(
-            final FishState fishState,
-            final AlgorithmFactory<? extends Regulation> regulationsFactory,
-            final PurseSeineGearFactory<B, F> purseSeineGearFactory,
-            final AlgorithmFactory<? extends DestinationStrategy> gravityDestinationStrategyFactory,
-            final AlgorithmFactory<? extends FishingStrategy> fishingStrategyFactory, PurseSeinerDepartingStrategyFactory departingStrategy
+    @NotNull
+    FisherFactory makeFisherFactory(
+        final FishState fishState,
+        final AlgorithmFactory<? extends Regulation> regulationsFactory,
+        final PurseSeineGearFactory<B, F> purseSeineGearFactory,
+        final AlgorithmFactory<? extends DestinationStrategy> gravityDestinationStrategyFactory,
+        final AlgorithmFactory<? extends FishingStrategy> fishingStrategyFactory,
+        PurseSeinerDepartingStrategyFactory departingStrategy
     ) {
         final FisherFactory fisherFactory = new FisherFactory(
-                null,
-                regulationsFactory,
-                departingStrategy,
-                gravityDestinationStrategyFactory,
-                fishingStrategyFactory,
-                new NoDiscardingFactory(),
-                gearStrategy,
-                new IgnoreWeatherFactory(),
-                null,
-                null,
-                purseSeineGearFactory,
-                0
+            null,
+            regulationsFactory,
+            departingStrategy,
+            gravityDestinationStrategyFactory,
+            fishingStrategyFactory,
+            new NoDiscardingFactory(),
+            gearStrategy,
+            new IgnoreWeatherFactory(),
+            null,
+            null,
+            purseSeineGearFactory,
+            0
         );
 
         fisherFactory.getAdditionalSetups().addAll(ImmutableList.of(
-                fisher -> ((CompositeDepartingStrategy) fisher.getDepartingStrategy())
-                        .getStrategies()
-                        .stream()
-                        .filter(strategy -> strategy instanceof DestinationBasedDepartingStrategy)
-                        .map(strategy -> (DestinationBasedDepartingStrategy) strategy)
-                        .forEach(strategy -> strategy.setDestinationStrategy(fisher.getDestinationStrategy())),
-                addHourlyCosts(),
-                fisher -> ((PurseSeineGear<?, ?>) fisher.getGear()).getFadManager().setFisher(fisher),
-                fisher -> scheduleClosurePeriodChoice(fishState, fisher),
-                fisher -> fisher.getYearlyData().registerGatherer(
-                        "Profits",
-                        fisher1 -> fisher1.getYearlyCounterColumn(EARNINGS)
-                                - fisher1.getYearlyCounterColumn(VARIABLE_COSTS),
-                        Double.NaN
-                ),
-                fisher -> fisher.getYearlyCounter().addColumn("Distance travelled"),
-                fisher -> fisher.getYearlyData().registerGatherer("Distance travelled", fisher1 ->
-                        fisher1.getYearlyCounterColumn("Distance travelled"), Double.NaN
-                ),
-                fisher -> fisher.addTripListener((tripRecord, fisher1) ->
-                                                         fisher1.getYearlyCounter()
-                                                                 .count("Distance travelled", tripRecord.getDistanceTravelled())
-                )
+            fisher -> ((CompositeDepartingStrategy) fisher.getDepartingStrategy())
+                .getStrategies()
+                .stream()
+                .filter(strategy -> strategy instanceof DestinationBasedDepartingStrategy)
+                .map(strategy -> (DestinationBasedDepartingStrategy) strategy)
+                .forEach(strategy -> strategy.setDestinationStrategy(fisher.getDestinationStrategy())),
+            addHourlyCosts(),
+            fisher -> ((PurseSeineGear<?, ?>) fisher.getGear()).getFadManager().setFisher(fisher),
+            fisher -> scheduleClosurePeriodChoice(fishState, fisher),
+            fisher -> fisher.getYearlyData().registerGatherer(
+                "Profits",
+                fisher1 -> fisher1.getYearlyCounterColumn(EARNINGS)
+                    - fisher1.getYearlyCounterColumn(VARIABLE_COSTS),
+                Double.NaN
+            ),
+            fisher -> fisher.getYearlyCounter().addColumn("Distance travelled"),
+            fisher -> fisher.getYearlyData().registerGatherer("Distance travelled", fisher1 ->
+                fisher1.getYearlyCounterColumn("Distance travelled"), Double.NaN
+            ),
+            fisher -> fisher.addTripListener((tripRecord, fisher1) ->
+                fisher1.getYearlyCounter()
+                    .count("Distance travelled", tripRecord.getDistanceTravelled())
+            )
         ));
 
         return fisherFactory;
     }
-
 
     @SuppressWarnings("UnstableApiUsage")
     private Consumer<Fisher> addHourlyCosts() {
@@ -308,5 +313,9 @@ public abstract class EpoScenario<B extends LocalBiology, F extends Fad<B, F>>
 
     public FadRefillGearStrategyFactory getGearStrategy() {
         return gearStrategy;
+    }
+
+    public void setGearStrategy(final FadRefillGearStrategyFactory gearStrategy) {
+        this.gearStrategy = gearStrategy;
     }
 }

--- a/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/ActionWeightsCacheTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/ActionWeightsCacheTest.java
@@ -40,7 +40,7 @@ public class ActionWeightsCacheTest {
     @Test
     public void test() {
 
-        final String headers = "boat_id,year,event,w";
+        final String headers = "ves_no,year,event,w";
         final Path path1 = makeTempFile(String.join(
             System.getProperty("line.separator"),
             headers,

--- a/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/LocationFisherValuesByActionCacheTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/caches/LocationFisherValuesByActionCacheTest.java
@@ -53,7 +53,7 @@ public class LocationFisherValuesByActionCacheTest {
 
         final Path path = makeTempFile(String.join(
             System.getProperty("line.separator"),
-            "boat_id,year,lon,lat,event,value",
+            "ves_no,year,lon,lat,event,value",
             "Fisher0,2017,0.5,0.5,OFS,10",
             "Fisher0,2017,0.5,1.5,OFS,20",
             "Fisher0,2017,0.5,2.5,OFS,30",

--- a/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManagerTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManagerTest.java
@@ -18,10 +18,8 @@
 
 package uk.ac.ox.oxfish.fisher.purseseiner.fads;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager.getFadManager;
 
 import ec.util.MersenneTwisterFast;
 import junit.framework.TestCase;
@@ -31,7 +29,7 @@ import uk.ac.ox.oxfish.fisher.Fisher;
 import uk.ac.ox.oxfish.fisher.purseseiner.actions.FadSetAction;
 import uk.ac.ox.oxfish.fisher.purseseiner.equipment.PurseSeineGear;
 import uk.ac.ox.oxfish.geography.SeaTile;
-import uk.ac.ox.oxfish.geography.fads.BiomassFadInitializer;
+import uk.ac.ox.oxfish.geography.fads.FadInitializer;
 import uk.ac.ox.oxfish.geography.fads.FadMap;
 import uk.ac.ox.oxfish.model.FishState;
 import uk.ac.ox.oxfish.model.regs.Anarchy;
@@ -42,15 +40,13 @@ public class FadManagerTest extends TestCase {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void testFadsGoBackInStockAfterSet() {
 
-        final BiomassFadInitializer fadInitializer = mock(BiomassFadInitializer.class);
-        when(fadInitializer.makeFad(any(), any(), any())).then(invocation -> {
-            final BiomassFad fad = mock(BiomassFad.class);
-            final Fisher fisher = invocation.getArgument(1, Fisher.class);
-            final FadManager fadManager = getFadManager(fisher);
-            when(fad.getOwner()).thenReturn(fadManager);
-            when(fad.getBiology()).thenReturn(new BiomassLocalBiology(new double[] {0}));
-            return fad;
-        });
+        final FadInitializer<BiomassLocalBiology, BiomassFad> fadInitializer =
+            (fadManager, owner, initialLocation) -> {
+                final BiomassFad fad = mock(BiomassFad.class);
+                when(fad.getOwner()).thenReturn(fadManager);
+                when(fad.getBiology()).thenReturn(new BiomassLocalBiology(new double[] {0}));
+                return fad;
+            };
 
         final FadMap fadMap = mock(FadMap.class);
 

--- a/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManagerTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/fisher/purseseiner/fads/FadManagerTest.java
@@ -1,0 +1,104 @@
+/*
+ * POSEIDON, an agent-based model of fisheries
+ * Copyright (C) 2021 CoHESyS Lab cohesys.lab@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package uk.ac.ox.oxfish.fisher.purseseiner.fads;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.ac.ox.oxfish.fisher.purseseiner.fads.FadManager.getFadManager;
+
+import ec.util.MersenneTwisterFast;
+import junit.framework.TestCase;
+import uk.ac.ox.oxfish.biology.BiomassLocalBiology;
+import uk.ac.ox.oxfish.biology.GlobalBiology;
+import uk.ac.ox.oxfish.fisher.Fisher;
+import uk.ac.ox.oxfish.fisher.purseseiner.actions.FadSetAction;
+import uk.ac.ox.oxfish.fisher.purseseiner.equipment.PurseSeineGear;
+import uk.ac.ox.oxfish.geography.SeaTile;
+import uk.ac.ox.oxfish.geography.fads.BiomassFadInitializer;
+import uk.ac.ox.oxfish.geography.fads.FadMap;
+import uk.ac.ox.oxfish.model.FishState;
+import uk.ac.ox.oxfish.model.regs.Anarchy;
+import uk.ac.ox.oxfish.model.regs.Regulation;
+
+public class FadManagerTest extends TestCase {
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testFadsGoBackInStockAfterSet() {
+
+        final BiomassFadInitializer fadInitializer = mock(BiomassFadInitializer.class);
+        when(fadInitializer.makeFad(any(), any(), any())).then(invocation -> {
+            final BiomassFad fad = mock(BiomassFad.class);
+            final Fisher fisher = invocation.getArgument(1, Fisher.class);
+            final FadManager fadManager = getFadManager(fisher);
+            when(fad.getOwner()).thenReturn(fadManager);
+            when(fad.getBiology()).thenReturn(new BiomassLocalBiology(new double[] {0}));
+            return fad;
+        });
+
+        final FadMap fadMap = mock(FadMap.class);
+
+        final FadManager<BiomassLocalBiology, BiomassFad> fadManager =
+            new FadManager(fadMap, fadInitializer);
+
+        final PurseSeineGear purseSeineGear = mock(PurseSeineGear.class);
+        when(purseSeineGear.getFadManager()).thenReturn(fadManager);
+
+        final GlobalBiology globalBiology = GlobalBiology.genericListOfSpecies(1);
+        final FishState fishState = mock(FishState.class);
+        when(fishState.getStep()).thenReturn(1);
+        when(fishState.getFadMap()).thenReturn(fadMap);
+        when(fishState.getBiology()).thenReturn(globalBiology);
+
+        final MersenneTwisterFast rng = mock(MersenneTwisterFast.class);
+
+        final SeaTile seaTile = mock(SeaTile.class);
+        final Regulation anarchy = new Anarchy();
+        final Fisher fisher = mock(Fisher.class);
+        when(fisher.grabState()).thenReturn(fishState);
+        when(fisher.getGear()).thenReturn(purseSeineGear);
+        when(fisher.grabRandomizer()).thenReturn(rng);
+        when(fisher.getRegulation()).thenReturn(anarchy);
+        when(fisher.getLocation()).thenReturn(seaTile);
+
+        fadManager.setFisher(fisher);
+        fadManager.setNumFadsInStock(10);
+        final BiomassFad fad1 = fadManager.deployFad(seaTile);
+
+        assertEquals(9, fadManager.getNumFadsInStock());
+        assertEquals(1, fadManager.getNumDeployedFads());
+
+        // try a successful set
+        when(rng.nextDouble()).thenReturn(1.0);
+        new FadSetAction<>(fad1, fisher, 1.0)
+            .act(fishState, fadManager.getFisher(), anarchy, 24);
+        assertEquals(10, fadManager.getNumFadsInStock());
+
+        final BiomassFad fad2 = fadManager.deployFad(seaTile);
+        assertEquals(9, fadManager.getNumFadsInStock());
+        assertEquals(2, fadManager.getNumDeployedFads());
+
+        // try with a failed set
+        when(rng.nextDouble()).thenReturn(1.0);
+        new FadSetAction<>(fad2, fisher, 1.0)
+            .act(fishState, fadManager.getFisher(), anarchy, 24);
+        assertEquals(10, fadManager.getNumFadsInStock());
+
+    }
+}


### PR DESCRIPTION
This required some minor changes to the main code:

- the unique id for vessels is now `ves_no` instead of `boat_id`, so this has been updated where needed.
- `max_deployments` now has a `year` field instead of just contained the number for the target year.