### PR TITLE
make sure SpecificProtectedAreas are initialized correctly

### DIFF
--- a/src/main/java/uk/ac/ox/oxfish/model/regs/SpecificProtectedArea.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/regs/SpecificProtectedArea.java
@@ -1,60 +1,39 @@
 package uk.ac.ox.oxfish.model.regs;
 
-import com.google.common.collect.ImmutableSet;
-import sim.engine.SimState;
-import sim.engine.Steppable;
-import sim.util.geo.MasonGeometry;
 import uk.ac.ox.oxfish.biology.Species;
 import uk.ac.ox.oxfish.fisher.Fisher;
-import uk.ac.ox.oxfish.geography.NauticalMap;
 import uk.ac.ox.oxfish.geography.SeaTile;
 import uk.ac.ox.oxfish.model.FishState;
-import uk.ac.ox.oxfish.model.StepOrder;
-
-import java.util.Collection;
 
 /**
  * A regulation that enforces a single, specific protected area.
  * <p>
  * Stores the protected status of each tile in the {@code inArea} array for speed of access.
- * {@code updateProtectedArea} needs to be called if a tile's MPA is ever modified.
- * <p>
- * This is fast but memory hungry, as each fisher gets its own Regulation object. If/when we migrate
- * protected areas to the ActionSpecificRegulation interface, we'll be able to use a single
- * array for the whole simulation.
+ * The array is not meant to ever be modified. If MPAs need to change during a simulation,
+ * a new SpecificProtectedArea should be created.
  */
 public class SpecificProtectedArea implements Regulation {
 
-    private final ImmutableSet<MasonGeometry> masonGeometries;
-    private boolean[][] inArea;
+    private final boolean[][] inArea;
+    private final String name;
 
-    public SpecificProtectedArea(Collection<MasonGeometry> masonGeometries) {
-        this.masonGeometries = ImmutableSet.copyOf(masonGeometries);
+    public SpecificProtectedArea(final boolean[][] inArea, String name) {
+        this.inArea = inArea.clone();
+        this.name = name;
+    }
+
+    public boolean[][] getInAreaArrayClone() {
+        return inArea.clone();
     }
 
     @Override
-    public void start(FishState model, Fisher fisher) {
-        Regulation.super.start(model, fisher);
-        model.scheduleOnce(
-                (Steppable) simState -> updateProtectedArea(model), StepOrder.DAWN
-        );
-
+    public boolean canFishHere(Fisher agent, SeaTile tile, FishState model, int timeStep) {
+        return !isProtected(tile);
     }
 
-    public void updateProtectedArea(FishState model) {
-        NauticalMap map = model.getMap();
-        int w = map.getWidth();
-        int h = map.getHeight();
-        inArea = new boolean[w][h];
-        for (int x = 0; x < w; x++)
-            for (int y = 0; y < h; y++)
-                inArea[x][y] = masonGeometries.contains(map.getSeaTile(x, y).grabMPA());
+    public boolean isProtected(SeaTile tile) {
+        return inArea[tile.getGridX()][tile.getGridY()];
     }
-
-    @Override
-    public boolean canFishHere(Fisher agent, SeaTile tile, FishState model, int timeStep) { return !isProtected(tile); }
-
-    public boolean isProtected(SeaTile tile) { return inArea[tile.getGridX()][tile.getGridY()]; }
 
     @Override
     public double maximumBiomassSellable(
@@ -62,12 +41,24 @@ public class SpecificProtectedArea implements Regulation {
         Species species,
         FishState model,
         int timeStep
-    ) { return Double.MAX_VALUE; }
+    ) {
+        return Double.MAX_VALUE;
+    }
 
     @Override
-    public boolean allowedAtSea(Fisher fisher, FishState model, int timeStep) { return true; }
+    public boolean allowedAtSea(Fisher fisher, FishState model, int timeStep) {
+        return true;
+    }
 
     @Override
-    public Regulation makeCopy() { return new SpecificProtectedArea(masonGeometries); }
+    public Regulation makeCopy() {
+        return new SpecificProtectedArea(inArea, name);
+    }
 
+    @Override
+    public String toString() {
+        return "SpecificProtectedArea{" +
+            "name='" + name + '\'' +
+            '}';
+    }
 }

--- a/src/main/java/uk/ac/ox/oxfish/model/regs/factory/SpecificProtectedAreaFromCoordinatesFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/regs/factory/SpecificProtectedAreaFromCoordinatesFactory.java
@@ -1,15 +1,14 @@
 package uk.ac.ox.oxfish.model.regs.factory;
 
-import com.google.common.collect.ImmutableSet;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
 import ec.util.MersenneTwisterFast;
-import sim.util.geo.MasonGeometry;
+import uk.ac.ox.oxfish.geography.NauticalMap;
 import uk.ac.ox.oxfish.model.FishState;
 import uk.ac.ox.oxfish.utility.parameters.DoubleParameter;
 import uk.ac.ox.oxfish.utility.parameters.FixedDoubleParameter;
+
+import java.util.function.BiPredicate;
 
 public class SpecificProtectedAreaFromCoordinatesFactory extends SpecificProtectedAreaFactory {
 
@@ -30,27 +29,59 @@ public class SpecificProtectedAreaFromCoordinatesFactory extends SpecificProtect
         this.eastLongitude = new FixedDoubleParameter(eastLongitude);
     }
 
-    @SuppressWarnings("unused") public SpecificProtectedAreaFromCoordinatesFactory() {
+    @SuppressWarnings("unused")
+    public SpecificProtectedAreaFromCoordinatesFactory() {
         this(1, 1, 1, 1);
     }
 
-    @SuppressWarnings("unused") public DoubleParameter getNorthLatitude() { return northLatitude; }
-    @SuppressWarnings("unused") public void setNorthLatitude(DoubleParameter northLatitude) { this.northLatitude = northLatitude; }
-    @SuppressWarnings("unused") public DoubleParameter getWestLongitude() { return westLongitude; }
-    @SuppressWarnings("unused") public void setWestLongitude(DoubleParameter westLongitude) { this.westLongitude = westLongitude; }
-    @SuppressWarnings("unused") public DoubleParameter getSouthLatitude() { return southLatitude; }
-    @SuppressWarnings("unused") public void setSouthLatitude(DoubleParameter southLatitude) { this.southLatitude = southLatitude; }
-    @SuppressWarnings("unused") public DoubleParameter getEastLongitude() { return eastLongitude; }
-    @SuppressWarnings("unused") public void setEastLongitude(DoubleParameter eastLongitude) { this.eastLongitude = eastLongitude; }
+    @SuppressWarnings("unused")
+    public DoubleParameter getNorthLatitude() {
+        return northLatitude;
+    }
 
-    @Override ImmutableSet<MasonGeometry> buildGeometries(FishState fishState) {
+    @SuppressWarnings("unused")
+    public void setNorthLatitude(DoubleParameter northLatitude) {
+        this.northLatitude = northLatitude;
+    }
+
+    @SuppressWarnings("unused")
+    public DoubleParameter getWestLongitude() {
+        return westLongitude;
+    }
+
+    @SuppressWarnings("unused")
+    public void setWestLongitude(DoubleParameter westLongitude) {
+        this.westLongitude = westLongitude;
+    }
+
+    @SuppressWarnings("unused")
+    public DoubleParameter getSouthLatitude() {
+        return southLatitude;
+    }
+
+    @SuppressWarnings("unused")
+    public void setSouthLatitude(DoubleParameter southLatitude) {
+        this.southLatitude = southLatitude;
+    }
+
+    @SuppressWarnings("unused")
+    public DoubleParameter getEastLongitude() {
+        return eastLongitude;
+    }
+
+    @SuppressWarnings("unused")
+    public void setEastLongitude(DoubleParameter eastLongitude) {
+        this.eastLongitude = eastLongitude;
+    }
+
+    @Override
+    BiPredicate<Integer, Integer> inAreaPredicate(FishState fishState) {
+        final NauticalMap map = fishState.getMap();
         final MersenneTwisterFast rng = fishState.getRandom();
-        final GeometryFactory geometryFactory = new GeometryFactory();
         final Envelope envelope = new Envelope(
             new Coordinate(westLongitude.apply(rng), northLatitude.apply(rng)),
             new Coordinate(eastLongitude.apply(rng), southLatitude.apply(rng))
         );
-        final Geometry geometry = geometryFactory.toGeometry(envelope);
-        return ImmutableSet.of(new MasonGeometry(geometry));
+        return (x, y) -> envelope.covers(map.getCoordinates(x, y));
     }
 }

--- a/src/main/java/uk/ac/ox/oxfish/model/scenario/StandardIattcRegulationsFactory.java
+++ b/src/main/java/uk/ac/ox/oxfish/model/scenario/StandardIattcRegulationsFactory.java
@@ -52,7 +52,7 @@ public class StandardIattcRegulationsFactory implements AlgorithmFactory<Multipl
     public static final ProtectedAreasFromFolderFactory PROTECTED_AREAS_FROM_FOLDER_FACTORY =
         new ProtectedAreasFromFolderFactory(
             EpoScenario.INPUT_PATH.resolve("regions"),
-            Paths.get("tags.csv")
+            Paths.get("region_tags.csv")
         );
     private AlgorithmFactory<TemporaryRegulation> closureAReg = CLOSURE_A_REG;
     private AlgorithmFactory<TemporaryRegulation> closureBReg = CLOSURE_B_REG;

--- a/src/main/java/uk/ac/ox/oxfish/utility/GISReaders.java
+++ b/src/main/java/uk/ac/ox/oxfish/utility/GISReaders.java
@@ -100,7 +100,7 @@ public class GISReaders {
         return  vectorField;
     }
 
-    private static GeomVectorField readShapeFile(String filename) {
+    public static GeomVectorField readShapeFile(String filename) {
         URL resource = GISReaders.class.getClassLoader().getResource(filename);
         File input = null;
         if(resource!= null)

--- a/src/test/java/uk/ac/ox/oxfish/model/regs/factory/SpecificProtectedAreaFactoryTest.java
+++ b/src/test/java/uk/ac/ox/oxfish/model/regs/factory/SpecificProtectedAreaFactoryTest.java
@@ -1,0 +1,120 @@
+package uk.ac.ox.oxfish.model.regs.factory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Booleans;
+import com.vividsolutions.jts.geom.Coordinate;
+import junit.framework.TestCase;
+import uk.ac.ox.oxfish.model.FishState;
+import uk.ac.ox.oxfish.model.regs.MultipleRegulations;
+import uk.ac.ox.oxfish.model.regs.SpecificProtectedArea;
+import uk.ac.ox.oxfish.model.scenario.EpoAbundanceScenario;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getLast;
+import static java.util.stream.Collectors.*;
+import static uk.ac.ox.oxfish.model.scenario.EpoScenario.INPUT_PATH;
+import static uk.ac.ox.oxfish.model.scenario.TestableScenario.startTestableScenario;
+import static uk.ac.ox.oxfish.utility.csv.CsvParserUtil.recordStream;
+
+public class SpecificProtectedAreaFactoryTest extends TestCase {
+
+    final FishState fishState = startTestableScenario(EpoAbundanceScenario.class);
+
+    public void testEveryEEZHasTilesInArea() {
+        final Set<SpecificProtectedArea> areas = fishState.getFishers().stream().flatMap(fisher ->
+            ((MultipleRegulations) fisher.getRegulation()).getRegulations()
+                .stream()
+                .filter(reg -> reg instanceof SpecificProtectedArea)
+                .map(reg -> (SpecificProtectedArea) reg)
+        ).collect(toSet());
+
+        final ImmutableList<SpecificProtectedArea> areasWithNoTiles =
+            areas.stream()
+                .filter(reg ->
+                    Arrays.stream(reg.getInAreaArrayClone())
+                        .noneMatch(booleans ->
+                            Booleans.asList(booleans).stream().anyMatch(Boolean::booleanValue)
+                        )
+                )
+                .collect(toImmutableList());
+
+        assertEquals(ImmutableList.of(), areasWithNoTiles);
+    }
+
+    public void testEEZPoints() {
+
+        final Map<String, List<TestPoint>> testPoints =
+            recordStream(INPUT_PATH.resolve("tests")
+                .resolve("regions_test_points.csv"))
+                .collect(
+                    groupingBy(
+                        record -> record.getString("flag"),
+                        mapping(
+                            record -> new TestPoint(
+                                record.getString("eez_name"),
+                                record.getString("flag"),
+                                record.getBoolean("allowed"),
+                                new Coordinate(record.getDouble("lon"), record.getDouble("lat"))
+                            ),
+                            toList()
+                        )
+                    )
+                );
+
+        final ImmutableList<TestPoint> failures =
+            fishState.getFishers()
+                .stream()
+                .flatMap(fisher ->
+                    testPoints
+                        .get(getLast(fisher.getTags()))
+                        .stream()
+                        .filter(testPoint ->
+                            testPoint.shouldBeAllowed !=
+                                fisher.getRegulation().canFishHere(
+                                    fisher,
+                                    fishState.getMap().getSeaTile(testPoint.coordinate),
+                                    fishState,
+                                    100 // make sure we're outside of IATTC January closure
+                                )
+                        )
+                )
+                .collect(toImmutableList());
+
+        assertEquals(ImmutableList.of(), failures);
+
+    }
+
+    private static class TestPoint {
+        final String eezName;
+        final String flag;
+        final boolean shouldBeAllowed;
+        final Coordinate coordinate;
+
+        private TestPoint(
+            String eezName,
+            String flag,
+            boolean shouldBeAllowed,
+            Coordinate coordinate
+        ) {
+            this.eezName = eezName;
+            this.flag = flag;
+            this.shouldBeAllowed = shouldBeAllowed;
+            this.coordinate = coordinate;
+        }
+
+        @Override
+        public String toString() {
+            return "TestPoint{" +
+                "eezName='" + eezName + '\'' +
+                ", flag='" + flag + '\'' +
+                ", shouldBeAllowed=" + shouldBeAllowed +
+                ", coordinate=" + coordinate +
+                '}';
+        }
+    }
+}


### PR DESCRIPTION
The main change is that those regulations don't rely on the SeaTile
having a reference to the MPA's geometry object anymore. Every protected
area has an `inArea` array, indexed by grid coordinates, and that's all
that matters. That makes it easy to share areas between simulations and
saves us from having to call `recomputeTilesMPA` on the map when they're
initialized.

The main downside is that we don't see areas as grey zones in the GUI
anymore, but that's fixable, albeit low-priority.

I also added a pair of test that checks, for a set of points including
one in each EEZ, that regulations are applied correctly. That made me
realize that GeoMason was reading only the first polygon in multipolygon
shapes. I fixed that upstream (in https://github.com/poseidon-fisheries/tuna/commit/e9fdbe26ced2f28d72b1615c882bcfa4200c41d7) by
taking only the largest polygon in each EEZ.